### PR TITLE
Bugfixes for version 1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
 Parse MockDB
 =====================
 
+#Bugfixes for version 1.6.2
+
+This branch features some semi-tested but not completely tested bugfixes for parse sdk 1.6.2
+
+The major change in the parse 1.6 is that the Parse._request has been replaced with _RESTController.request() This isn't exposed through the normal means (that I can find so far) so this code works if you add the following line of code to the parse SDK at line #1095
+
+/*
+
+	CUSTOM CODE #1000
+
+*/
+Parse.RESTController = _dereq_('./RESTController');
+/*
+
+	END CUSTOM CODE #1000
+
+*/
+
+
+
+
+
 Master Build Status: [![Circle CI](https://circleci.com/gh/HustleInc/parse-mockdb/tree/master.svg?style=svg)](https://circleci.com/gh/HustleInc/parse-mockdb/tree/master)
 
 (Originally forked from parse-mock, https://github.com/dziamid/parse-mock)

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -114,7 +114,8 @@ function cleanUp() {
   hooks = {};
   Parse.Object.prototype.save.restore();
   Parse.Object.saveAll.restore();
-  Parse._request.restore();
+  //Parse._request.restore();
+  Parse.RESTController.request.restore();
 }
 
 /**
@@ -122,19 +123,41 @@ function cleanUp() {
  * successful response based on the request parameters
  */
 function stubRequests() {
-  sinon.stub(Parse, '_request', function(options) {
+  sinon.stub(Parse.RESTController, 'request', function(method,url,params,options) {
+
+	url = url.replace('classes/','');
+	var className = "";
+	if(url.lastIndexOf('/') !== -1){
+		className = url.substring(0,url.lastIndexOf('/'));
+	}
+	else{
+		className = url;
+	}
+	var id = url.substring(url.lastIndexOf('/') + 1);
+
+	var data = {};
+	data.className = className;
+	if(id){
+		data.objectId = id;
+	}
+	if(params){
+		data.data = params;
+	}
+
+
     var response, status, xhr;
-    switch (options.method) {
+    switch (method) {
     case "GET":
-      response = stubGetRequest(options);
+      response = stubGetRequest(data);
       status = "200";
       break;
+
     case "POST":
-      response = stubPostOrPutRequest(options);
+      response = stubPostOrPutRequest(data);
       status = "201";
       break;
     case "PUT":
-      response = stubPostOrPutRequest(options);
+      response = stubPostOrPutRequest(data);
       status = "200";
       break;
     default:
@@ -202,8 +225,8 @@ function promiseResultSync(promise) {
 function storableFormat(object, className) {
   var storableData = {
     id: object.id,
-    createdAt: object.createdAt.toJSON(),
-    updatedAt: object.updatedAt.toJSON(),
+//    createdAt: object.createdAt.toJSON(),
+//    updatedAt: object.updatedAt.toJSON(),
     className: className,
   };
   _.each(object.attributes, function(v, k) {


### PR DESCRIPTION
Hi

Thanks for a great repo that is very useful. I've had some issues with the latest parse skd 1.6.x as below. The code committed isn't fully tested but I think it's a step in the right direction towards compatibility. I'm not familiar with parse code so it might not be the most efficient

This branch features some semi-tested but not completely tested bugfixes for parse sdk 1.6.2

The major change in the parse 1.6 is that the Parse._request has been replaced with _RESTController.request() This isn't exposed through the normal means (that I can find so far) so this code works if you add the following line of code to the parse SDK at line #1095

/*

	CUSTOM CODE #1000

*/
Parse.RESTController = _dereq_('./RESTController');
/*

	END CUSTOM CODE #1000

*/