### PR TITLE
Fix 'Cannot read property 'mockDB' of undefined' error

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -55,11 +55,11 @@ function itemQueryP(price) {
 
 describe('ParseMock', function(){
   beforeEach(function() {
-    Parse.MockDB.mockDB();
+    ParseMockDB.mockDB();
   });
 
   afterEach(function() {
-    Parse.MockDB.cleanUp();
+    ParseMockDB.cleanUp();
   });
 
   it("should save correctly", function(done) {


### PR DESCRIPTION
I couldn't get the tests to run. Some old syntax left over.