### PR TITLE
User subclass beforeSave support

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -278,23 +278,27 @@ function handleRequest(method, path, body) {
 
   var request;
 
-  if (explodedPath[0] === 'classes') {
-    request = {
-      method: method,
-      className: explodedPath[1],
-      data: body,
-      objectId: explodedPath[2],
-    };
-  } else if (explodedPath[0] === 'users') {
-    request = {
-      method: method,
-      className: '_User',
-      data: body,
-      objectId: explodedPath[1],
-    };
-  } else {
-    debugPrint('WARN', 'Unhandled path in request: ' + path);
+  switch(explodedPath[0]) {
+    case 'users': {
+      request = {
+        method: method,
+        className: '_User',
+        data: body,
+        objectId: explodedPath[1],
+      };
+      break;
+    }
+    case 'classes':
+    default: {
+      request = {
+        method: method,
+        className: explodedPath[1],
+        data: body,
+        objectId: explodedPath[2],
+      };
+    }
   }
+
   return HANDLERS[method](request);
 }
 

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -76,14 +76,14 @@ function runHook(className, hookType, data) {
 
     // TODO Stub out Parse.Cloud.useMasterKey() so that we can report the correct 'master'
     // value here.
-    var beforeSaveRequest = {
+    var beforeSaveOrBeforeDeleteRequestObject = {
       installationId: 'parse-mockdb',
       master: false,
       object: model,
       user: "ParseMockDB doesn't define request.user."
     };
 
-    return hook(beforeSaveRequest).then((result) => {
+    return hook(beforeSaveOrBeforeDeleteRequestObject).then((result) => {
       debugPrint('HOOK', { result });
       var newData = _.cloneDeep(result.toJSON());
       return Parse.Promise.as(_.omit(newData, "ACL"));

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -74,7 +74,16 @@ function runHook(className, hookType, data) {
     var modelData = Object.assign(new Object, data, {className});
     var model = Parse.Object.fromJSON(_.omit(modelData, "ACL"));
 
-    return hook.bind(model)().then((result) => {
+    // TODO Stub out Parse.Cloud.useMasterKey() so that we can report the correct 'master'
+    // value here.
+    var beforeSaveRequest = {
+      installationId: 'parse-mockdb',
+      master: false,
+      object: model,
+      user: "ParseMockDB doesn't define request.user."
+    };
+
+    return hook(beforeSaveRequest).then((result) => {
       debugPrint('HOOK', { result });
       var newData = _.cloneDeep(result.toJSON());
       return Parse.Promise.as(_.omit(newData, "ACL"));

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -275,12 +275,26 @@ function normalizePath(path) {
 
 function handleRequest(method, path, body) {
   var explodedPath = normalizePath(path).split('/');
-  var request = {
-    method: method,
-    className: explodedPath[1],
-    data: body,
-    objectId: explodedPath[2],
-  };
+
+  var request;
+
+  if (explodedPath[0] === 'classes') {
+    request = {
+      method: method,
+      className: explodedPath[1],
+      data: body,
+      objectId: explodedPath[2],
+    };
+  } else if (explodedPath[0] === 'users') {
+    request = {
+      method: method,
+      className: '_User',
+      data: body,
+      objectId: explodedPath[1],
+    };
+  } else {
+    debugPrint('WARN', 'Unhandled path in request: ' + path);
+  }
   return HANDLERS[method](request);
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -783,12 +783,14 @@ describe('ParseMock', function(){
  */
 
   context('when object has beforeSave hook registered', function() {
-    function beforeSave() {
-      if (this.get("error")) {
+
+    function beforeSave(request) {
+      var brand = request.object;
+      if (brand.get("error")) {
         return Parse.Promise.error("whoah");
       }
-      this.set('cool', true);
-      return Parse.Promise.as(this);
+      brand.set('cool', true);
+      return Parse.Promise.as(brand);
     }
 
     it('runs the hook before saving the model and persists the object', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -839,7 +839,7 @@ describe('ParseMock', function(){
         return Parse.Promise.error("whoah");
       }
       beforeDeleteWasRun = true;
-      return Parse.Promise.as(brand);
+      return Parse.Promise.as();
     }
 
     it('runs the hook before deleting the object', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -191,32 +191,9 @@ describe('ParseMock', function(){
       });
     });
 
-    // TODO Run all tests as shared behaviour between Object and User.
-    function beforeSavePromise(request) {
-      var brand = request.object;
-      if (brand.get("error")) {
-        return Parse.Promise.error("whoah");
-      }
-      brand.set('cool', true);
-      return Parse.Promise.as(brand);
-    }
+    behavesLikeParseObjectOnBeforeSave('_User', CustomUserSubclass);
 
-    it('runs the hook before saving the model and persists the object', function() {
-      ParseMockDB.registerHook('_User', 'beforeSave', beforeSavePromise);
-
-      var brand = new CustomUserSubclass();
-      assert(!brand.has('cool'));
-
-      brand.save().then(function (savedCustomUserSubclass) {
-        assert(savedCustomUserSubclass.has('cool'));
-        assert(savedCustomUserSubclass.get('cool'));
-
-        new Parse.Query(CustomUserSubclass).first().then(function (queriedCustomUserSubclass) {
-          assert(queriedCustomUserSubclass.has('cool'));
-          assert(queriedCustomUserSubclass.get('cool'));
-        });
-      });
-    })
+    behavesLikeParseObjectOnBeforeDelete('_User', CustomUserSubclass);
 
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -65,6 +65,7 @@ function behavesLikeParseObjectOnBeforeSave() {
 
   context('when object has beforeSave hook registered', function() {
 
+    var ParseObjectOrUserSubclass = Brand;
     var typeName = 'Brand';
 
     function beforeSavePromise(request) {
@@ -79,14 +80,14 @@ function behavesLikeParseObjectOnBeforeSave() {
     it('runs the hook before saving the model and persists the object', function() {
       ParseMockDB.registerHook(typeName, 'beforeSave', beforeSavePromise);
 
-      var object = new Brand();
+      var object = new ParseObjectOrUserSubclass();
       assert(!object.has('cool'));
 
       object.save().then(function (savedObject) {
         assert(savedObject.has('cool'));
         assert(savedObject.get('cool'));
 
-        new Parse.Query(Brand).first().then(function (queriedObject) {
+        new Parse.Query(ParseObjectOrUserSubclass).first().then(function (queriedObject) {
           assert(queriedObject.has('cool'));
           assert(queriedObject.get('cool'));
         });
@@ -94,9 +95,9 @@ function behavesLikeParseObjectOnBeforeSave() {
     });
 
     it('rejects the save if there is a problem', function(done) {
-      ParseMockDB.registerHook('Brand', 'beforeSave', beforeSavePromise);
+      ParseMockDB.registerHook(typeName, 'beforeSave', beforeSavePromise);
 
-      var object = new Brand({error: true});
+      var object = new ParseObjectOrUserSubclass({error: true});
 
       object.save().then(function (savedObject) {
         throw new Error("should not have saved")

--- a/test/test.js
+++ b/test/test.js
@@ -799,12 +799,12 @@ describe('ParseMock', function(){
       var brand = new Brand();
       assert(!brand.has('cool'));
 
-      brand.save().then(savedBrand => {
+      brand.save().then(function (savedBrand) {
         assert(savedBrand.has('cool'));
         assert(savedBrand.get('cool'));
 
         var q = new Parse.Query(Brand);
-        q.first().then(queriedBrand => {
+        q.first().then(function (queriedBrand) {
           assert(queriedBrand.has('cool'));
           assert(queriedBrand.get('cool'));
         });
@@ -816,9 +816,9 @@ describe('ParseMock', function(){
 
       var brand = new Brand({error: true});
 
-      brand.save().then(savedBrand => {
+      brand.save().then(function (savedBrand) {
         throw new Error("should not have saved")
-      }, error => {
+      }, function(error) {
         assert.equal(error, "whoah");
         done();
       });
@@ -851,7 +851,7 @@ describe('ParseMock', function(){
         assert(beforeDeleteWasRun);
       });
 
-      new Parse.Query(Brand).find().done(results => {
+      new Parse.Query(Brand).find().done(function (results) {
         assert.equal(results.length, 0);
       });
     });
@@ -862,13 +862,13 @@ describe('ParseMock', function(){
       var brand = new Brand({error: true});
       brand.save().done(function (savedBrand) {
         return Parse.Object.destroyAll([savedBrand]);
-      }).then(deletedBrand => {
+      }).then(function (deletedBrand) {
         throw new Error("should not have deleted")
-      }, error => {
+      }, function(error) {
         assert.equal(error, "whoah");
 
         return new Parse.Query(Brand).find();
-      }).done(results => {
+      }).done(function(results) {
         assert.equal(results.length, 1);
         done();
       });

--- a/test/test.js
+++ b/test/test.js
@@ -65,6 +65,8 @@ function behavesLikeParseObjectOnBeforeSave() {
 
   context('when object has beforeSave hook registered', function() {
 
+    var typeName = 'Brand';
+
     function beforeSavePromise(request) {
       var object = request.object;
       if (object.get("error")) {
@@ -75,7 +77,7 @@ function behavesLikeParseObjectOnBeforeSave() {
     }
 
     it('runs the hook before saving the model and persists the object', function() {
-      ParseMockDB.registerHook('Brand', 'beforeSave', beforeSavePromise);
+      ParseMockDB.registerHook(typeName, 'beforeSave', beforeSavePromise);
 
       var object = new Brand();
       assert(!object.has('cool'));

--- a/test/test.js
+++ b/test/test.js
@@ -96,9 +96,9 @@ function behavesLikeParseObjectOnBeforeSave() {
     it('rejects the save if there is a problem', function(done) {
       ParseMockDB.registerHook('Brand', 'beforeSave', beforeSavePromise);
 
-      var brand = new Brand({error: true});
+      var object = new Brand({error: true});
 
-      brand.save().then(function (savedBrand) {
+      object.save().then(function (savedObject) {
         throw new Error("should not have saved")
       }, function(error) {
         assert.equal(error, "whoah");

--- a/test/test.js
+++ b/test/test.js
@@ -66,27 +66,27 @@ function behavesLikeParseObjectOnBeforeSave() {
   context('when object has beforeSave hook registered', function() {
 
     function beforeSavePromise(request) {
-      var brand = request.object;
-      if (brand.get("error")) {
+      var object = request.object;
+      if (object.get("error")) {
         return Parse.Promise.error("whoah");
       }
-      brand.set('cool', true);
-      return Parse.Promise.as(brand);
+      object.set('cool', true);
+      return Parse.Promise.as(object);
     }
 
     it('runs the hook before saving the model and persists the object', function() {
       ParseMockDB.registerHook('Brand', 'beforeSave', beforeSavePromise);
 
-      var brand = new Brand();
-      assert(!brand.has('cool'));
+      var object = new Brand();
+      assert(!object.has('cool'));
 
-      brand.save().then(function (savedBrand) {
-        assert(savedBrand.has('cool'));
-        assert(savedBrand.get('cool'));
+      object.save().then(function (savedObject) {
+        assert(savedObject.has('cool'));
+        assert(savedObject.get('cool'));
 
-        new Parse.Query(Brand).first().then(function (queriedBrand) {
-          assert(queriedBrand.has('cool'));
-          assert(queriedBrand.get('cool'));
+        new Parse.Query(Brand).first().then(function (queriedObject) {
+          assert(queriedObject.has('cool'));
+          assert(queriedObject.get('cool'));
         });
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,8 @@ class Store extends Parse.Object {
 }
 Parse.Object.registerSubclass('Store', Store);
 
+class CustomUserSubclass extends Parse.User {}
+
 function createBrandP(name) {
   var brand = new Brand();
   brand.set("name", name);
@@ -47,6 +49,12 @@ function createStoreWithItemP(item) {
   return store.save();
 }
 
+function createUserP(name) {
+  var user = new CustomUserSubclass()
+  user.set('name', name);
+  return user.save();
+}
+
 function itemQueryP(price) {
   var query = new Parse.Query(Item);
   query.equalTo("price", price);
@@ -60,6 +68,31 @@ describe('ParseMock', function(){
 
   afterEach(function() {
     Parse.MockDB.cleanUp();
+  });
+
+  context('user class', function() {
+
+    it("should save user ", function(done) {
+      createUserP('Tom').then(function(user) {
+        console.log('user:' + JSON.stringify(user));
+        assert(user.get("name") === 'Tom');
+        done();
+      });
+    });
+
+    it('should save and find a user', function (done) {
+      createUserP('Tom').then(function(user) {
+        var query = new Parse.Query(CustomUserSubclass);
+        query.equalTo("name", 'Tom');
+        return query.first().then(function(user) {
+          assert(user.get('name') === 'Tom');
+          done();
+        });
+      });
+    });
+
+    // TODO Extract shared behaviours...
+
   });
 
   it("should save correctly", function(done) {

--- a/test/test.js
+++ b/test/test.js
@@ -127,30 +127,30 @@ function behavesLikeParseObjectOnBeforeDelete(typeName, ParseObjectOrUserSubclas
     }
 
     it('runs the hook before deleting the object', function() {
-      ParseMockDB.registerHook('Brand', 'beforeDelete', beforeDeletePromise);
+      ParseMockDB.registerHook(typeName, 'beforeDelete', beforeDeletePromise);
 
-      new Brand().save().done(function (savedBrand) {
-        return Parse.Object.destroyAll([savedBrand]);
+      new ParseObjectOrUserSubclass().save().done(function (savedParseObjectOrUserSubclass) {
+        return Parse.Object.destroyAll([savedParseObjectOrUserSubclass]);
       }).done(function () {
           assert(beforeDeleteWasRun);
         });
 
-      new Parse.Query(Brand).find().done(function (results) {
+      new Parse.Query(ParseObjectOrUserSubclass).find().done(function (results) {
         assert.equal(results.length, 0);
       });
     });
 
     it('rejects the delete if there is a problem', function(done) {
-      ParseMockDB.registerHook('Brand', 'beforeDelete', beforeDeletePromise);
+      ParseMockDB.registerHook(typeName, 'beforeDelete', beforeDeletePromise);
 
-      var object = new Brand({error: true});
-      object.save().done(function (savedBrand) {
-        return Parse.Object.destroyAll([savedBrand]);
-      }).then(function (deletedBrand) {
+      var object = new ParseObjectOrUserSubclass({error: true});
+      object.save().done(function (savedParseObjectOrUserSubclass) {
+        return Parse.Object.destroyAll([savedParseObjectOrUserSubclass]);
+      }).then(function (deletedParseObjectOrUserSubclass) {
           throw new Error("should not have deleted")
         }, function(error) {
           assert.equal(error, "whoah");
-          return new Parse.Query(Brand).find();
+          return new Parse.Query(ParseObjectOrUserSubclass).find();
         }).done(function(results) {
           assert.equal(results.length, 1);
           done();

--- a/test/test.js
+++ b/test/test.js
@@ -91,7 +91,7 @@ describe('ParseMock', function(){
       });
     });
 
-    // TODO Extract shared behaviours...
+    // TODO Run all tests as shared behaviour between Object and User.
 
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -784,7 +784,7 @@ describe('ParseMock', function(){
 
   context('when object has beforeSave hook registered', function() {
 
-    function beforeSave(request) {
+    function beforeSavePromise(request) {
       var brand = request.object;
       if (brand.get("error")) {
         return Parse.Promise.error("whoah");
@@ -794,7 +794,7 @@ describe('ParseMock', function(){
     }
 
     it('runs the hook before saving the model and persists the object', function() {
-      ParseMockDB.registerHook('Brand', 'beforeSave', beforeSave);
+      ParseMockDB.registerHook('Brand', 'beforeSave', beforeSavePromise);
 
       var brand = new Brand();
       assert(!brand.has('cool'));
@@ -812,7 +812,7 @@ describe('ParseMock', function(){
     })
 
     it('rejects the save if there is a problem', function(done) {
-      ParseMockDB.registerHook('Brand', 'beforeSave', beforeSave);
+      ParseMockDB.registerHook('Brand', 'beforeSave', beforeSavePromise);
 
       var brand = new Brand({error: true});
 

--- a/test/test.js
+++ b/test/test.js
@@ -851,7 +851,10 @@ describe('ParseMock', function(){
         assert(beforeDeleteWasRun);
       });
 
-      // TODO Assert that no brands should exist in the backend.
+      var q = new Parse.Query(Brand);
+      q.find().done(results => {
+        assert(results.length === 0);
+      });
     });
 
     it('rejects the delete if there is a problem', function(done) {

--- a/test/test.js
+++ b/test/test.js
@@ -70,11 +70,10 @@ describe('ParseMock', function(){
     Parse.MockDB.cleanUp();
   });
 
-  context('user class', function() {
+  context('supports Parse.User subclasses', function() {
 
-    it("should save user ", function(done) {
+    it("should save user", function(done) {
       createUserP('Tom').then(function(user) {
-        console.log('user:' + JSON.stringify(user));
         assert(user.get("name") === 'Tom');
         done();
       });

--- a/test/test.js
+++ b/test/test.js
@@ -61,12 +61,9 @@ function itemQueryP(price) {
   return query.find();
 }
 
-function behavesLikeParseObjectOnBeforeSave() {
+function behavesLikeParseObjectOnBeforeSave(typeName, ParseObjectOrUserSubclass) {
 
   context('when object has beforeSave hook registered', function() {
-
-    var ParseObjectOrUserSubclass = Brand;
-    var typeName = 'Brand';
 
     function beforeSavePromise(request) {
       var object = request.object;
@@ -899,7 +896,7 @@ describe('ParseMock', function(){
  *  });
  */
 
-  behavesLikeParseObjectOnBeforeSave();
+  behavesLikeParseObjectOnBeforeSave('Brand', Brand);
 
   context('when object has beforeDelete hook registered', function() {
 

--- a/test/test.js
+++ b/test/test.js
@@ -851,9 +851,8 @@ describe('ParseMock', function(){
         assert(beforeDeleteWasRun);
       });
 
-      var q = new Parse.Query(Brand);
-      q.find().done(results => {
-        assert(results.length === 0);
+      new Parse.Query(Brand).find().done(results => {
+        assert.equal(results.length, 0);
       });
     });
 
@@ -867,6 +866,10 @@ describe('ParseMock', function(){
         throw new Error("should not have deleted")
       }, error => {
         assert.equal(error, "whoah");
+
+        return new Parse.Query(Brand).find();
+      }).done(results => {
+        assert.equal(results.length, 1);
         done();
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -118,8 +118,8 @@ function behavesLikeParseObjectOnBeforeDelete(typeName, ParseObjectOrUserSubclas
     });
 
     function beforeDeletePromise(request) {
-      var brand = request.object;
-      if (brand.get("error")) {
+      var object = request.object;
+      if (object.get("error")) {
         return Parse.Promise.error("whoah");
       }
       beforeDeleteWasRun = true;
@@ -129,7 +129,7 @@ function behavesLikeParseObjectOnBeforeDelete(typeName, ParseObjectOrUserSubclas
     it('runs the hook before deleting the object', function() {
       ParseMockDB.registerHook('Brand', 'beforeDelete', beforeDeletePromise);
 
-      createBrandP().done(function (savedBrand) {
+      new Brand().save().done(function (savedBrand) {
         return Parse.Object.destroyAll([savedBrand]);
       }).done(function () {
           assert(beforeDeleteWasRun);
@@ -143,8 +143,8 @@ function behavesLikeParseObjectOnBeforeDelete(typeName, ParseObjectOrUserSubclas
     it('rejects the delete if there is a problem', function(done) {
       ParseMockDB.registerHook('Brand', 'beforeDelete', beforeDeletePromise);
 
-      var brand = new Brand({error: true});
-      brand.save().done(function (savedBrand) {
+      var object = new Brand({error: true});
+      object.save().done(function (savedBrand) {
         return Parse.Object.destroyAll([savedBrand]);
       }).then(function (deletedBrand) {
           throw new Error("should not have deleted")

--- a/test/test.js
+++ b/test/test.js
@@ -845,8 +845,7 @@ describe('ParseMock', function(){
     it('runs the hook before deleting the object', function() {
       ParseMockDB.registerHook('Brand', 'beforeDelete', beforeDeletePromise);
 
-      var brand = new Brand();
-      brand.save().done(function (savedBrand) {
+      createBrandP().done(function (savedBrand) {
         return Parse.Object.destroyAll([savedBrand]);
       }).done(function () {
         assert(beforeDeleteWasRun);

--- a/test/test.js
+++ b/test/test.js
@@ -803,8 +803,7 @@ describe('ParseMock', function(){
         assert(savedBrand.has('cool'));
         assert(savedBrand.get('cool'));
 
-        var q = new Parse.Query(Brand);
-        q.first().then(function (queriedBrand) {
+        new Parse.Query(Brand).first().then(function (queriedBrand) {
           assert(queriedBrand.has('cool'));
           assert(queriedBrand.get('cool'));
         });

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,31 @@ describe('ParseMock', function(){
     });
 
     // TODO Run all tests as shared behaviour between Object and User.
+    function beforeSavePromise(request) {
+      var brand = request.object;
+      if (brand.get("error")) {
+        return Parse.Promise.error("whoah");
+      }
+      brand.set('cool', true);
+      return Parse.Promise.as(brand);
+    }
+
+    it('runs the hook before saving the model and persists the object', function() {
+      ParseMockDB.registerHook('_User', 'beforeSave', beforeSavePromise);
+
+      var brand = new CustomUserSubclass();
+      assert(!brand.has('cool'));
+
+      brand.save().then(function (savedCustomUserSubclass) {
+        assert(savedCustomUserSubclass.has('cool'));
+        assert(savedCustomUserSubclass.get('cool'));
+
+        new Parse.Query(CustomUserSubclass).first().then(function (queriedCustomUserSubclass) {
+          assert(queriedCustomUserSubclass.has('cool'));
+          assert(queriedCustomUserSubclass.get('cool'));
+        });
+      });
+    })
 
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -822,8 +822,8 @@ describe('ParseMock', function(){
         assert.equal(error, "whoah");
         done();
       });
-    })
-  })
+    });
+  });
 
   context('when object has beforeDelete hook registered', function() {
 

--- a/test/test.js
+++ b/test/test.js
@@ -859,9 +859,10 @@ describe('ParseMock', function(){
       ParseMockDB.registerHook('Brand', 'beforeDelete', beforeDeletePromise);
 
       var brand = new Brand({error: true});
-
-      brand.save().then(savedBrand => {
-        throw new Error("should not have saved")
+      brand.save().done(function (savedBrand) {
+        return Parse.Object.destroyAll([savedBrand]);
+      }).then(deletedBrand => {
+        throw new Error("should not have deleted")
       }, error => {
         assert.equal(error, "whoah");
         done();

--- a/test/test.js
+++ b/test/test.js
@@ -865,7 +865,6 @@ describe('ParseMock', function(){
         throw new Error("should not have deleted")
       }, function(error) {
         assert.equal(error, "whoah");
-
         return new Parse.Query(Brand).find();
       }).done(function(results) {
         assert.equal(results.length, 1);

--- a/test/test.js
+++ b/test/test.js
@@ -838,6 +838,7 @@ describe('ParseMock', function(){
       if (brand.get("error")) {
         return Parse.Promise.error("whoah");
       }
+      beforeDeleteWasRun = true;
       return Parse.Promise.as(brand);
     }
 


### PR DESCRIPTION
Fixes #9 with only partial coverage. It should be good enough — as long as the key requests know that users are special cases and uses `_User` as class name we're all good.