### PR TITLE
Make asserts and promises play together

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "node": ">=5.0.0"
   },
   "scripts": {
-    "test": "mocha ./test/test"
+    "test": "mocha ./test/test",
+    "lint": "eslint src/** test/**"
   },
   "repository": {
     "type": "git",
@@ -35,5 +36,18 @@
   },
   "directories": {
     "test": "test"
+  },
+  "eslintConfig": {
+    "parserOptions": {
+      "ecmaVersion": 6
+    },
+    "env": {
+      "node": true,
+      "mocha": true
+    },
+    "rules": {
+      "semi": ["error", "always"],
+      "space-before-function-paren": ["error", "never"]
+    }
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -62,112 +62,102 @@ describe('ParseMock', function(){
     Parse.MockDB.cleanUp();
   });
 
-  it("should save correctly", function(done) {
-    createItemP(30).then(function(item) {
+  it("should save correctly", function() {
+    return createItemP(30).then(function(item) {
       assert.equal(item.get("price"), 30);
-      done();
     });
   });
 
-  it("should come back with createdAt", function(done) {
+  it("should come back with createdAt", function() {
     var createdAt;
-    createItemP(30).then(function(item) {
+    return createItemP(30).then(function(item) {
       assert(item.createdAt);
       createdAt = item.createdAt;
       return (new Parse.Query(Item)).first();
     }).then((fetched) => {
       assert.equal(createdAt.getTime(), fetched.createdAt.getTime());
-      done();
     });
   });
 
-  it("should get a specific ID correctly", function(done) {
-    createItemP(30).then(function(item) {
+  it("should get a specific ID correctly", function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
-      query.get(item.id).then(function(fetchedItem) {
+      return query.get(item.id).then(function(fetchedItem) {
         assert.equal(fetchedItem.id, item.id);
-        done();
       });
     });
   });
 
-  it("should match a correct equalTo query on price", function(done) {
-    createItemP(30).then(function(item) {
-      itemQueryP(30).then(function(results) {
+  it("should match a correct equalTo query on price", function() {
+    return createItemP(30).then(function(item) {
+      return itemQueryP(30).then(function(results) {
         assert.equal(results[0].id, item.id);
         assert.equal(results[0].get("price"), item.get("price"));
-        done();
       });
     });
   });
 
-  it('should save and find an item', function(done) {
+  it('should save and find an item', function() {
     const item = new Item();
     item.set("price", 30);
-    item.save().then(function(item) {
+    return item.save().then(function(item) {
       const query = new Parse.Query(Item);
       query.equalTo("price", 30);
       return query.first().then(function(item) {
         assert.equal(item.get("price"), 30);
-        done();
       });
     });
   });
 
-  it('should save and find an item via object comparison', function(done) {
-    const item = new Item({cool: {awesome: true } });
-    item.save().then(function(item) {
+  it('should save and find an item via object comparison', function() {
+    const item = new Item({ cool: {awesome: true} });
+    return item.save().then(function(item) {
       const query = new Parse.Query(Item);
       query.equalTo('cool', {awesome: true});
       return query.first().then(function(item) {
         assert(item.get('cool').awesome);
-        done();
       });
     });
   });
 
-  it('should support increment', function(done) {
-    createItemP(30).then(function(item) {
+  it('should support increment', function() {
+    return createItemP(30).then(function(item) {
       item.increment("price", 5);
       return item.save();
     }).then(function(item) {
       assert.equal(item.get("price"), 35);
-      done();
     });
   });
 
-  it('should support negative increment', function(done) {
-    createItemP(30).then(function(item) {
+  it('should support negative increment', function() {
+    return createItemP(30).then(function(item) {
       item.increment("price", -5);
       return item.save();
     }).then(function(item) {
       assert.equal(item.get("price"), 25);
-      done();
     });
   });
 
-  it('should support unset', function(done) {
-    createItemP(30).then(function(item) {
+  it('should support unset', function() {
+    return createItemP(30).then(function(item) {
       item.unset("price");
       return item.save();
     }).then(function(item) {
       assert(!item.has("price"));
-      done();
     });
   });
 
-  it('should support add', function(done) {
-    createItemP(30).then(function(item) {
+  it('should support add', function() {
+    return createItemP(30).then(function(item) {
       item.add("languages", "JS");
       return item.save();
     }).then(function(item) {
       assert.deepEqual(item.get("languages"), ["JS"]);
-      done();
     });
   });
 
-  it('should support addUnique', function(done) {
-    createItemP(30).then(function(item) {
+  it('should support addUnique', function() {
+    return createItemP(30).then(function(item) {
       item.add("languages", "JS");
       item.add("languages", "Ruby")
       return item.save();
@@ -177,12 +167,11 @@ describe('ParseMock', function(){
       return item.save();
     }).then(function(item) {
       assert.deepEqual(item.get("languages"), ["JS", "Ruby"]);
-      done();
     });
   });
 
-  it('should support remove', function(done) {
-    createItemP(30).then(function(item) {
+  it('should support remove', function() {
+    return createItemP(30).then(function(item) {
       item.add("languages", "JS");
       item.add("languages", "JS");
       item.add("languages", "Ruby")
@@ -193,17 +182,16 @@ describe('ParseMock', function(){
       return item.save();
     }).then(function(item) {
       assert.deepEqual(item.get("languages"), ["Ruby"]);
-      done();
     });
   });
 
-  it('should saveAll and find 2 items', function(done) {
+  it('should saveAll and find 2 items', function() {
     const item = new Item();
     item.set("price", 30);
 
     const item2 = new Item();
     item2.set("price", 30);
-    Parse.Object.saveAll([item, item2]).then(function(items) {
+    return Parse.Object.saveAll([item, item2]).then(function(items) {
       assert.equal(items.length, 2);
       const query = new Parse.Query(Item);
       query.equalTo("price", 30);
@@ -211,16 +199,15 @@ describe('ParseMock', function(){
         assert.equal(items.length, 2);
         assert.equal(items[0].get("price"), 30);
         assert.equal(items[1].get("price"), 30);
-        done();
       });
     });
   });
 
-  it('should find an item matching an or query', function(done) {
+  it('should find an item matching an or query', function() {
     const Item = Parse.Object.extend("Item");
     const item = new Item();
     item.set("price", 30);
-    item.save().then(function(item) {
+    return item.save().then(function(item) {
       const query = new Parse.Query(Item);
       query.equalTo("price", 30);
 
@@ -230,16 +217,15 @@ describe('ParseMock', function(){
       const orQuery = Parse.Query.or(query, otherQuery);
       return orQuery.find().then(function(items) {
         assert.equal(items[0].id, item.id);
-        done();
       });
     });
   });
 
-  it('should not find any items if they do not match an or query', function(done) {
+  it('should not find any items if they do not match an or query', function() {
     const Item = Parse.Object.extend("Item");
     const item = new Item();
     item.set("price", 30);
-    item.save().then(function(item) {
+    return item.save().then(function(item) {
       const query = new Parse.Query(Item);
       query.equalTo("price", 50);
 
@@ -249,45 +235,42 @@ describe('ParseMock', function(){
       const orQuery = Parse.Query.or(query, otherQuery);
       return orQuery.find().then(function(items) {
         assert.equal(items.length, 0);
-        done();
       });
     });
   });
 
-  it('should save 2 items and get one for a first() query', function(done) {
-    Parse.Promise.when(createItemP(30), createItemP(20)).then(function(item1, item2) {
+  it('should save 2 items and get one for a first() query', function() {
+    return Parse.Promise.when(createItemP(30), createItemP(20)).then(function(item1, item2) {
       const query = new Parse.Query(Item);
       return query.first().then(function(item) {
         assert.equal(item.get("price"), 30);
-        done();
       });
     });
   });
 
-  it("should handle nested includes", function(done) {
-    createBrandP("Acme").then(function(brand) {
-      createItemP(30, brand).then(function(item) {
+  it("should handle nested includes", function() {
+    return createBrandP("Acme").then(function(brand) {
+      return createItemP(30, brand).then(function(item) {
         const brand = item.get("brand");
-        createStoreWithItemP(item).then(function(savedStore) {
+        return createStoreWithItemP(item).then(function(savedStore) {
           const query = new Parse.Query(Store);
           query.include("item");
           query.include("item.brand");
-          query.first().then(function(result) {
+          return query.first().then(function(result) {
             const resultItem = result.get("item");
             const resultBrand = resultItem.get("brand");
             assert.equal(resultItem.id, item.id);
             assert.equal(resultBrand.get("name"), "Acme");
             assert.equal(resultBrand.id, brand.id);
-            done();
           });
         });
       });
     });
   });
 
-  it("should handle multiple nested includes", function(done) {
+  it("should handle multiple nested includes", function() {
     var a1, a2, b, c;
-    Parse.Promise.when(
+    return Parse.Promise.when(
         new Parse.Object('a', {value: '1'}).save(),
         new Parse.Object('a', {value: '2'}).save())
     .then(function(savedA1, savedA2) {
@@ -314,19 +297,14 @@ describe('ParseMock', function(){
       assert.equal(loadedC.get('b').get('a2').id, a2.id);
       assert.equal(loadedC.get('b').get('a1').get('value'), a1.get('value'));
       assert.equal(loadedC.get('b').get('a2').get('value'), a2.get('value'));
-
-      done();
-    })
-    .then(null, function(err) {
-      done(err);
     });
   });
 
-  it('should handle includes over arrays of pointers', function(done) {
+  it('should handle includes over arrays of pointers', function() {
     const item1 = new Item({cool: true});
     const item2 = new Item({cool: false});
     const items = [item1, item2];
-    Parse.Object.saveAll(items).then(function(savedItems) {
+    return Parse.Object.saveAll(items).then(function(savedItems) {
       const brand = new Brand({
         items: items
       });
@@ -337,16 +315,15 @@ describe('ParseMock', function(){
     }).then(function(brand) {
       assert(brand.get('items')[0].get('cool'));
       assert(!brand.get('items')[1].get('cool'));
-      done();
     });
   });
 
-  it('should handle nested includes over arrays of pointers', function(done) {
+  it('should handle nested includes over arrays of pointers', function() {
     const store = new Store({location: "SF"});
     const item1 = new Item({cool: true, store: store});
     const item2 = new Item({cool: false});
     const items = [item1, item2];
-    Parse.Object.saveAll(items.concat([store])).then(function(savedItems) {
+    return Parse.Object.saveAll(items.concat([store])).then(function(savedItems) {
       const brand = new Brand({
         items: items
       });
@@ -357,30 +334,28 @@ describe('ParseMock', function(){
     }).then(function(brand) {
       assert.equal(brand.get('items')[0].get("store").get("location"), "SF");
       assert(!brand.get('items')[1].get('cool'));
-      done();
     });
   });
 
-  it('should handle includes where item is missing', function(done) {
+  it('should handle includes where item is missing', function() {
     const item = new Item({cool: true});
     const brand1 = new Brand({});
     const brand2 = new Brand({item: item});
-    Parse.Object.saveAll([item, brand1, brand2]).then(function() {
+    return Parse.Object.saveAll([item, brand1, brand2]).then(function() {
       const q = new Parse.Query(Brand).include('item');
       return q.find();
     }).then(function(brands) {
       assert(!brands[0].has('item'));
       assert(brands[1].has('item'));
-      done();
     });
   });
 
-  it('should handle includes where nested array item is missing', function(done) {
+  it('should handle includes where nested array item is missing', function() {
     const store = new Store({location: "SF"});
     const item1 = new Item({cool: true, store: store});
     const item2 = new Item({cool: false});
     const items = [item1, item2];
-    Parse.Object.saveAll(items.concat([store])).then(function(savedItems) {
+    return Parse.Object.saveAll(items.concat([store])).then(function(savedItems) {
       const brand = new Brand({
         items: items
       });
@@ -391,13 +366,12 @@ describe('ParseMock', function(){
     }).then(function(brand) {
       assert(brand.get('items')[0].get('cool'));
       assert(!brand.get('items')[1].get('cool'));
-      done();
     });
   });
 
-  it('should handle delete', function(done) {
+  it('should handle delete', function() {
     const item = new Item();
-    item.save().then(function(item) {
+    return item.save().then(function(item) {
       return new Parse.Query(Item).first();
     }).then(function(foundItem) {
       assert(foundItem);
@@ -406,45 +380,44 @@ describe('ParseMock', function(){
       return new Parse.Query(Item).first();
     }).then(function(foundItem) {
       assert(!foundItem);
-      done();
     });
   });
 
-  it("should do a fetch query", function(done) {
+  it("should do a fetch query", function() {
     let savedItem;
-    new Item().save({price: 30}).then(function(item1) {
+    return new Item().save({price: 30}).then(function(item1) {
       savedItem = item1;
       return Item.createWithoutData(item1.id).fetch()
     }).then(function(fetched) {
       assert.equal(fetched.id, savedItem.id);
       assert.equal(fetched.get('price'), 30);
-    }).then(() => done(), (err) => done(err));
+    });
   });
 
-  it("should find with objectId", function(done) {
+  it("should find with objectId", function() {
     let savedItem;
-    new Item().save({price: 30}).then(function(item1) {
+    return new Item().save({price: 30}).then(function(item1) {
       savedItem = item1;
       return new Parse.Query(Item).equalTo('objectId', item1.id).first();
     }).then(function(fetched) {
       assert.equal(fetched.id, savedItem.id);
       assert.equal(fetched.get('price'), 30);
-    }).then(() => done(), (err) => done(err));
+    });
   });
 
-  it("should get objectId", function(done) {
+  it("should get objectId", function() {
     let savedItem;
-    new Item().save({price: 30}).then(function(item1) {
+    return new Item().save({price: 30}).then(function(item1) {
       savedItem = item1;
       return new Parse.Query(Item).get(item1.id);
     }).then(function(fetched) {
       assert.equal(fetched.id, savedItem.id);
       assert.equal(fetched.get('price'), 30);
-    }).then(() => done(), (err) => done(err));
+    });
   });
 
-  it("should find with objectId and where", function(done) {
-    Parse.Promise.when(
+  it("should find with objectId and where", function() {
+    return Parse.Promise.when(
       new Item().save({price: 30}),
       new Item().save({name: 'Device'})
     ).then(function(item1, item2) {
@@ -454,134 +427,124 @@ describe('ParseMock', function(){
       return itemQuery.find().then(function(items) {
         assert.equal(items.length, 0);
       });
-    }).then(() => done(), (err) => done(err));
+    });
   });
 
-  it("should match a correct when exists query", function(done) {
-    Parse.Promise.when(
+  it("should match a correct when exists query", function() {
+    return Parse.Promise.when(
       new Item().save({price: 30}),
       new Item().save({name: 'Device'})
     ).then(function(item1, item2) {
       const itemQuery = new Parse.Query(Item);
       itemQuery.exists('price');
-      itemQuery.find().then(function(items) {
+      return itemQuery.find().then(function(items) {
         assert.equal(items.length, 1);
         assert.equal(items[0].id, item1.id);
-        done();
       });
     });
   });
 
-  it("should match a correct when doesNotExist query", function(done) {
-    Parse.Promise.when(
+  it("should match a correct when doesNotExist query", function() {
+    return Parse.Promise.when(
       new Item().save({price: 30}),
       new Item().save({name: 'Device'})
     ).then(function(item1, item2) {
       const itemQuery = new Parse.Query(Item);
       itemQuery.doesNotExist('price');
-      itemQuery.find().then(function(itmes) {
+      return itemQuery.find().then(function(itmes) {
         assert.equal(itmes.length, 1);
         assert.equal(itmes[0].id, item2.id);
-        done();
       });
     });
   });
 
-  it("should match a correct equalTo query for an object", function(done) {
-    createItemP(30).then(function(item) {
+  it("should match a correct equalTo query for an object", function() {
+    return createItemP(30).then(function(item) {
       const store = new Store();
       store.set("item", item);
-      store.save().then(function(savedStore) {
+      return store.save().then(function(savedStore) {
         const query = new Parse.Query(Store);
         query.equalTo("item", item);
-        query.find().then(function(results) {
+        return query.find().then(function(results) {
           assert.equal(results[0].id, savedStore.id);
-          done();
         });
       });
     });
   });
 
-  it("should not match an incorrect equalTo query on price", function(done) {
-    createItemP(30).then(function(item) {
-      itemQueryP(20).then(function(results) {
+  it("should not match an incorrect equalTo query on price", function() {
+    return createItemP(30).then(function(item) {
+      return itemQueryP(20).then(function(results) {
         assert.equal(results.length, 0);
-        done();
       });
     });
   });
 
-  it("should not match an incorrect equalTo query on price and name", function(done) {
-    createItemP(30).then(function(item) {
+  it("should not match an incorrect equalTo query on price and name", function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.equalTo("price", 30);
       query.equalTo("name", "pants");
-      query.find().then(function(results) {
+      return query.find().then(function(results) {
         assert.equal(results.length, 0);
-        done();
       });
     });
   });
 
-  it("should not match an incorrect containedIn query", function(done) {
-    createItemP(30).then(function(item) {
+  it("should not match an incorrect containedIn query", function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.containedIn("price", [40, 90]);
-      query.find().then(function(results) {
+      return query.find().then(function(results) {
         assert.equal(results.length, 0);
-        done();
       });
     });
   });
 
-  it("should find 2 objects when there are 2 matches", function(done) {
-    Parse.Promise.when(createItemP(20), createItemP(20)).then(function(item1, item2) {
+  it("should find 2 objects when there are 2 matches", function() {
+    return Parse.Promise.when(createItemP(20), createItemP(20)).then(function(item1, item2) {
       const query = new Parse.Query(Item);
       query.equalTo("price", 20);
-      query.find().then(function(results) {
+      return query.find().then(function(results) {
         assert.equal(results.length, 2);
-        done();
       });
     });
   });
 
-  it("should first() 1 object when there are 2 matches", function(done) {
-    Parse.Promise.when(createItemP(20), createItemP(20)).then(function(item1, item2) {
+  it("should first() 1 object when there are 2 matches", function() {
+    return Parse.Promise.when(createItemP(20), createItemP(20)).then(function(item1, item2) {
       const query = new Parse.Query(Item);
       query.equalTo("price", 20);
-      query.first().then(function(result) {
+      return query.first().then(function(result) {
         assert.equal(result.id, item1.id);
-        done();
       });
     });
   });
 
-  it("should match a query with 1 objects when 2 objects are present", function(done) {
-    Parse.Promise.when(createItemP(20), createItemP(30)).then(function(item1, item2) {
+  it("should match a query with 1 objects when 2 objects are present", function() {
+    return Parse.Promise.when(createItemP(20), createItemP(30)).then(function(item1, item2) {
       const query = new Parse.Query(Item);
       query.equalTo("price", 20);
-      query.find().then(function(results) {
+      return query.find().then(function(results) {
         assert.equal(results.length, 1);
-        done();
       });
     });
   });
 
-  it('should match a date', function(done) {
+  it('should match a date', function() {
     const bornOnDate = new Date();
     const item = new Item({bornOnDate: bornOnDate});
 
-    item.save().then(function(item) {
+    return item.save().then(function(item) {
       const query = new Parse.Query(Item);
       query.equalTo("bornOnDate", bornOnDate);
-      query.first().then(function(result) {
+      return query.first().then(function(result) {
         assert(result.get("bornOnDate", bornOnDate));
-        done();
       });
     });
   });
 
-  it('should properly handle date in query operator', function(done) {
+  it('should properly handle date in query operator', function() {
     const bornOnDate = new Date();
     const middleDate = new Date();
     const expireDate = new Date();
@@ -593,77 +556,71 @@ describe('ParseMock', function(){
       expireDate: expireDate,
     });
 
-    item.save().then(function(item) {
+    return item.save().then(function(item) {
       const query = new Parse.Query(Item);
       query.lessThan("bornOnDate", middleDate);
       query.greaterThan("expireDate", middleDate);
-      query.first().then(function(result) {
+      return query.first().then(function(result) {
         assert(result);
-        done();
       });
     });
   });
 
-  it("should handle $nin", function(done) {
-    Parse.Promise.when(createItemP(20), createItemP(30)).then(function(item1, item2) {
+  it("should handle $nin", function() {
+    return Parse.Promise.when(createItemP(20), createItemP(30)).then(function(item1, item2) {
       const query = new Parse.Query(Item);
       query.notContainedIn("price", [30]);
       return query.find();
     }).then(function(results) {
       assert.equal(results.length, 1);
       assert.equal(results[0].get("price"), 20);
-      done();
-    }, function(error) {console.log(error)})
+    });
   });
 
-  it("should handle $nin on objectId", function(done) {
-    createItemP(30).then(function(item) {
+  it("should handle $nin on objectId", function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.notContainedIn("objectId", [item.id]);
       return query.find();
     }).then(function(results) {
       assert.equal(results.length, 0);
-      done();
     });
   });
 
-  it("should handle $nin with an empty array", function(done) {
-    createItemP(30).then(function(item) {
+  it("should handle $nin with an empty array", function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.notContainedIn("objectId", []);
       return query.find();
     }).then(function(results) {
       assert.equal(results.length, 1);
-      done();
     });
   });
 
-  it("should handle $regex queries", function(done) {
-    createBrandP("Acme").then(function(item) {
+  it("should handle $regex queries", function() {
+    return createBrandP("Acme").then(function(item) {
       const query = new Parse.Query(Brand);
       query.startsWith("name", "Ac");
       return query.find();
     }).then(function(results) {
       assert.equal(results.length, 1);
-      done();
     });
   });
 
 /**
  *  see: https://github.com/ParsePlatform/Parse-SDK-JS/issues/91
  *
-  it("should not overwrite included objects after a save", function(done) {
-    createBrandP("Acme").then(function(brand) {
-      createItemP(30, brand).then(function(item) {
-        createStoreWithItemP(item).then(function(store) {
+  it("should not overwrite included objects after a save", function() {
+    return createBrandP("Acme").then(function(brand) {
+      return createItemP(30, brand).then(function(item) {
+        return createStoreWithItemP(item).then(function(store) {
           const query = new Parse.Query(Store);
           query.include("item");
           query.include("item.brand");
-          query.first().then(function(str) {
+          return query.first().then(function(str) {
             str.set("lol", "wut");
-            str.save().then(function(newStore) {
+            return str.save().then(function(newStore) {
               assert.equal(str.get("item").get("brand").get("name"), brand.get("name"));
-              done();
             });
           });
         });
@@ -675,20 +632,19 @@ describe('ParseMock', function(){
 /**
  *  see: https://github.com/ParsePlatform/Parse-SDK-JS/issues/91
  *
-  it("should update an existing object correctly", function(done) {
-    Parse.Promise.when(createItemP(30), createItemP(20)).then(function(item1, item2) {
-      createStoreWithItemP(item1).then(function(store) {
+  it("should update an existing object correctly", function() {
+    return Parse.Promise.when(createItemP(30), createItemP(20)).then(function(item1, item2) {
+      return createStoreWithItemP(item1).then(function(store) {
         item2.set("price", 10);
         store.set("item", item2);
-        store.save().then(function(store) {
+        return store.save().then(function(store) {
           assert(store.has("item"));
           assert(store.get("item").get("price") === 10);
-          done();
         });
       });
     });
   });
-  */
+*/
 
   it("should support a nested query", function() {
     const brand = new Brand();
@@ -721,111 +677,104 @@ describe('ParseMock', function(){
     });
   });
 
-  it('should find items not filtered by a notContainedIn', function(done) {
-    createItemP(30).then(function(item) {
+  it('should find items not filtered by a notContainedIn', function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.equalTo("price", 30);
       query.notContainedIn("objectId", [234]);
-      query.find().then(function(items) {
+      return query.find().then(function(items) {
         assert.equal(items.length, 1);
-        done();
       });
     });
   });
 
-  it('should find not items filtered by a notContainedIn', function(done) {
-    createItemP(30).then(function(item) {
+  it('should find not items filtered by a notContainedIn', function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.equalTo("price", 30);
       query.notContainedIn("objectId", [item.id]);
-      query.find().then(function(items) {
+      return query.find().then(function(items) {
         assert.equal(items.length, 0);
-        done();
       });
     });
   });
 
-  it('should handle a lessThan query', function(done) {
-    createItemP(30).then(function(item) {
+  it('should handle a lessThan query', function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.lessThan("createdAt", new Date("2024-01-01T23:28:56.782Z"));
-      query.find().then(function(items) {
+      return query.find().then(function(items) {
         assert.equal(items.length, 1);
         const newQuery = new Parse.Query(Item);
         newQuery.greaterThan("createdAt", new Date());
-        newQuery.find().then(function(moreItems) {
+        return newQuery.find().then(function(moreItems) {
           assert.equal(moreItems.length, 0);
-          done();
         });
       });
     });
   });
 
-  it('should handle a lessThanOrEqualTo query', function(done) {
-    createItemP(30).then(function(item) {
+  it('should handle a lessThanOrEqualTo query', function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.lessThanOrEqualTo("price", 30);
-      query.find().then(function(items) {
+      return query.find().then(function(items) {
         assert.equal(items.length, 1);
         query.lessThanOrEqualTo("price", 20);
-        query.find().then(function(moreItems) {
+        return query.find().then(function(moreItems) {
           assert.equal(moreItems.length, 0);
-          done();
         });
       });
     });
   });
 
-  it('should handle a greaterThan query', function(done) {
-    createItemP(30).then(function(item) {
+  it('should handle a greaterThan query', function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.greaterThan("price", 20);
-      query.find().then(function(items) {
+      return query.find().then(function(items) {
         assert.equal(items.length, 1);
         query.greaterThan("price", 50);
-        query.find().then(function(moreItems) {
+        return query.find().then(function(moreItems) {
           assert.equal(moreItems.length, 0);
-          done();
         });
       });
     });
   });
 
-  it('should handle a greaterThanOrEqualTo query', function(done) {
-    createItemP(30).then(function(item) {
+  it('should handle a greaterThanOrEqualTo query', function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.greaterThanOrEqualTo("price", 30);
-      query.find().then(function(items) {
+      return query.find().then(function(items) {
         assert.equal(items.length, 1);
         query.greaterThanOrEqualTo("price", 50);
-        query.find().then(function(moreItems) {
+        return query.find().then(function(moreItems) {
           assert.equal(moreItems.length, 0);
-          done();
         });
       });
     });
   });
 
-  it('should handle multiple conditions for a single key', function(done) {
-    createItemP(30).then(function(item) {
+  it('should handle multiple conditions for a single key', function() {
+    return createItemP(30).then(function(item) {
       const query = new Parse.Query(Item);
       query.greaterThan("price", 20);
       query.lessThan("price", 40);
-      query.find().then(function(items) {
+      return query.find().then(function(items) {
         assert.equal(items.length, 1);
         query.greaterThan("price", 30);
-        query.find().then(function(moreItems) {
+        return query.find().then(function(moreItems) {
           assert.equal(moreItems.length, 0);
-          done();
         });
       });
     });
   });
 
-  it('should correcly handle matchesQuery', function(done) {
-    createBrandP("Acme").then(function(brand) {
-      createItemP(30, brand).then(function(item) {
-        createStoreWithItemP(item).then(function(store) {
+  it('should correcly handle matchesQuery', function() {
+    return createBrandP("Acme").then(function(brand) {
+      return createItemP(30, brand).then(function(item) {
+        return createStoreWithItemP(item).then(function(store) {
           const brandQuery = new Parse.Query(Brand);
           brandQuery.equalTo("name", "Acme");
 
@@ -835,47 +784,44 @@ describe('ParseMock', function(){
           const storeQuery = new Parse.Query(Store);
           storeQuery.matchesQuery("item", itemQuery);
 
-          storeQuery.find().then(function(store) {
+          return storeQuery.find().then(function(store) {
             assert(store);
-            done();
           });
         });
       });
     });
   });
 
-  it('should correctly count items in a matchesQuery', function(done) {
-    createBrandP("Acme").then(function(brand) {
-      createItemP(30, brand).then(function(item) {
-        createStoreWithItemP(item).then(function(store) {
+  it('should correctly count items in a matchesQuery', function() {
+    return createBrandP("Acme").then(function(brand) {
+      return createItemP(30, brand).then(function(item) {
+        return createStoreWithItemP(item).then(function(store) {
           const itemQuery = new Parse.Query(Item);
           itemQuery.equalTo("price", 30);
 
           const storeQuery = new Parse.Query(Store);
           storeQuery.matchesQuery("item", itemQuery);
-          storeQuery.count().then(function(storeCount) {
+          return storeQuery.count().then(function(storeCount) {
             assert.equal(storeCount, 1);
-            done();
           });
         });
       });
     });
   });
 
-  it('should skip and limit items appropriately', function(done) {
-    createBrandP("Acme").then(function(brand) {
-      createBrandP("Acme 2").then(function(brand2) {
+  it('should skip and limit items appropriately', function() {
+    return createBrandP("Acme").then(function(brand) {
+      return createBrandP("Acme 2").then(function(brand2) {
         const brandQuery = new Parse.Query(Brand);
         brandQuery.limit(1);
-        brandQuery.find().then(function(brands) {
+        return brandQuery.find().then(function(brands) {
           assert.equal(brands.length, 1);
           const brandQuery2 = new Parse.Query(Brand);
           brandQuery2.limit(1);
           brandQuery2.skip(1);
-          brandQuery2.find().then(function(moreBrands) {
+          return brandQuery2.find().then(function(moreBrands) {
             assert.equal(moreBrands.length, 1);
             assert.notEqual(moreBrands[0].id, brands[0].id);
-            done();
           });
         });
       });
@@ -884,28 +830,26 @@ describe('ParseMock', function(){
 
   // See github issue: https://github.com/ParsePlatform/Parse-SDK-JS/issues/89
   // and uncomment, delete or rewrite when resolved
-/*
- *  it('should deep save and update nested objects', function(done) {
- *    var brand = new Brand();
- *    brand.set("name", "Acme");
- *    brand.set("country", "US");
- *    var item = new Item();
- *    item.set("price", 30);
- *    item.set("country_code", "US");
- *    brand.set("items", [item]);
- *    brand.save().then(function(savedBrand) {
- *      assert(savedBrand.get("items")[0].get("price") === item.get("price"));
- *
- *      var item2 = new Item();
- *      item2.set("price", 20);
- *      brand.set("items", [item2]);
- *      return brand.save().then(function(updatedBrand) {
- *        assert(updatedBrand.get("items")[0].get("price") === 20);
- *        done();
- *      });
- *    });
- *  });
- */
+  // it('should deep save and update nested objects', function() {
+  //   const brand = new Brand();
+  //   brand.set("name", "Acme");
+  //   brand.set("country", "US");
+  //   const item = new Item();
+  //   item.set("price", 30);
+  //   item.set("country_code", "US");
+  //   brand.set("items", [item]);
+  //   return brand.save().then(function(savedBrand) {
+  //     assert.equal(savedBrand.get("items")[0].get("price"), item.get("price"));
+
+  //     const item2 = new Item();
+  //     item2.set("price", 20);
+  //     brand.set("items", [item2]);
+  //     return brand.save().then(function(updatedBrand) {
+  //       assert.equal(updatedBrand.get("items")[0].get("price"), 20);
+  //     });
+  //   });
+  // });
+
 
   context('when object has beforeSave hook registered', function() {
 
@@ -918,36 +862,34 @@ describe('ParseMock', function(){
       return Parse.Promise.as(brand);
     }
 
-    it('runs the hook before saving the model and persists the object', function(done) {
+    it('runs the hook before saving the model and persists the object', function() {
       ParseMockDB.registerHook('Brand', 'beforeSave', beforeSavePromise);
 
       const brand = new Brand();
       assert(!brand.has('cool'));
       brand.set('nestedObject', { foo: 3 });
 
-      brand.save().then(function(savedBrand) {
+      return brand.save().then(function(savedBrand) {
         assert(savedBrand.has('cool'), 'saved brand doesn\'t have cool');
         assert(savedBrand.get('cool'));
         assert.equal(savedBrand.get('nestedObject').foo, 3);
-        new Parse.Query(Brand).first().then(function(queriedBrand) {
+        return new Parse.Query(Brand).first().then(function(queriedBrand) {
           assert(queriedBrand.has('cool'));
           assert(queriedBrand.get('cool'));
           assert.equal(savedBrand.get('nestedObject').foo, 3);
-          done();
         });
       });
     });
 
-    it('rejects the save if there is a problem', function(done) {
+    it('rejects the save if there is a problem', function() {
       ParseMockDB.registerHook('Brand', 'beforeSave', beforeSavePromise);
 
       const brand = new Brand({error: true});
 
-      brand.save().then(function(savedBrand) {
+      return brand.save().then(function(savedBrand) {
         assert.fail(null, null, "should not have saved");
       }, function(error) {
         assert.equal(error, "whoah");
-        done();
       });
     });
   });
@@ -969,7 +911,7 @@ describe('ParseMock', function(){
       return Parse.Promise.as();
     }
 
-    it('runs the hook before deleting the object', function(done) {
+    it('runs the hook before deleting the object', function() {
       ParseMockDB.registerHook('Brand', 'beforeDelete', beforeDeletePromise);
       const promises = [];
 
@@ -979,18 +921,17 @@ describe('ParseMock', function(){
 
       promises.push(new Parse.Query(Brand).find());
 
-      Parse.Promise.when(promises).then(function(results) {
+      return Parse.Promise.when(promises).then(function(results) {
         assert(results[0]);
         assert.equal(results[1].length, 0);
-        done();
       });
     });
 
-    it('rejects the delete if there is a problem', function(done) {
+    it('rejects the delete if there is a problem', function() {
       ParseMockDB.registerHook('Brand', 'beforeDelete', beforeDeletePromise);
 
       const brand = new Brand({error: true});
-      brand.save().done(function(savedBrand) {
+      return brand.save().done(function(savedBrand) {
         return Parse.Object.destroyAll([savedBrand]);
       }).then(function(deletedBrand) {
         assert.fail(null, null, "should not have deleted");
@@ -999,13 +940,12 @@ describe('ParseMock', function(){
         return new Parse.Query(Brand).find();
       }).done(function(results) {
         assert.equal(results.length, 1);
-        done();
       });
     });
   });
 
-  it('successfully uses containsAll query', function(done) {
-    Parse.Promise.when(createItemP(30), createItemP(20)).then((item1, item2) => {
+  it('successfully uses containsAll query', function() {
+    return Parse.Promise.when(createItemP(30), createItemP(20)).then((item1, item2) => {
       const store = new Store({
         items: [item1.toPointer(), item2.toPointer()],
       });
@@ -1020,19 +960,18 @@ describe('ParseMock', function(){
         return query.find();
       }).then(stores => {
         assert.equal(stores.length, 0);
-        done();
       });
     });
   });
 
-  it('should handle relations', function(done) {
+  it('should handle relations', function() {
     const store = new Store();
 
     const paperTowels = createItemP(20, 'paper towels');
     const toothPaste = createItemP(30, 'tooth paste');
     const toothBrush = createItemP(50, 'tooth brush');
 
-    Parse.Promise.when(
+    return Parse.Promise.when(
       paperTowels,
       toothPaste,
       toothBrush
@@ -1055,11 +994,10 @@ describe('ParseMock', function(){
       return store.relation('items').query().find();
     }).then((items) => {
       assert.equal(items.length, 1);
-      done();
     });
   });
 
-  it('should handle a direct query on a relation field', function(done) {
+  it('should handle a direct query on a relation field', function() {
     const store = new Store({name: "store 1"});
     const store2 = new Store({name: "store 2"});
     var tpId;
@@ -1067,7 +1005,7 @@ describe('ParseMock', function(){
     const paperTowels = createItemP(20, 'paper towels');
     const toothPaste = createItemP(30, 'tooth paste');
     const toothBrush = createItemP(50, 'tooth brush');
-    Parse.Promise.when(
+    return Parse.Promise.when(
       paperTowels,
       toothPaste,
       toothBrush,
@@ -1086,37 +1024,34 @@ describe('ParseMock', function(){
     }).then((results) => {
       assert.equal(results.length, 1);
       assert.equal(results[0].get('name'), "store 2");
-      done();
     });
   });
 
-  it('should handle the User class', function(done) {
+  it('should handle the User class', function() {
     const user = new Parse.User({name: "Turtle"});
-    user.save().then((savedUser) => {
+    return user.save().then((savedUser) => {
       return (new Parse.Query(Parse.User).find())
     }).then((foundUsers) => {
       assert.equal(foundUsers.length, 1);
       assert.equal(foundUsers[0].get('name'), "Turtle");
-      done();
     });
   });
 
-  it('should handle the Role class', function(done) {
+  it('should handle the Role class', function() {
     const roleACL = new Parse.ACL();
     roleACL.setPublicReadAccess(true);
     const role = new Parse.Role("Turtle", roleACL);
-    role.save().then((savedRole) => {
+    return role.save().then((savedRole) => {
       return (new Parse.Query(Parse.Role).find())
     }).then((foundRoles) => {
       assert.equal(foundRoles.length, 1);
       assert.equal(foundRoles[0].get('name'), "Turtle");
-      done();
     });
   });
 
-  it('should handle redirectClassNameForKey', function(done) {
+  it('should handle redirectClassNameForKey', function() {
     const user = new Parse.User({name: "T Rutlidge"})
-    user.save().then((savedUser) => {
+    return user.save().then((savedUser) => {
       const roleACL = new Parse.ACL();
       roleACL.setPublicReadAccess(true);
 
@@ -1130,6 +1065,6 @@ describe('ParseMock', function(){
     }).then((foundUsers) => {
       assert.equal(foundUsers.length, 1);
       assert.equal(foundUsers[0].get('name'), "T Rutlidge");
-    }).then(() => done(), err => done(err));
+    });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -716,8 +716,8 @@ describe('ParseMock', function(){
       storeQuery.matchesKeyInQuery("state", "state", itemQuery);
       return Parse.Promise.when(storeQuery.find(), Parse.Promise.as(store));
     }).then(function(storeMatches, store) {
-      assert(storeMatches.length == 1);
-      assert(storeMatches[0].id == store.id);
+      assert.equal(storeMatches.length, 1);
+      assert.equal(storeMatches[0].id, store.id);
     });
   });
 
@@ -727,7 +727,7 @@ describe('ParseMock', function(){
       query.equalTo("price", 30);
       query.notContainedIn("objectId", [234]);
       query.find().then(function(items) {
-        assert(items.length == 1);
+        assert.equal(items.length, 1);
         done();
       });
     });
@@ -739,7 +739,7 @@ describe('ParseMock', function(){
       query.equalTo("price", 30);
       query.notContainedIn("objectId", [item.id]);
       query.find().then(function(items) {
-        assert(items.length == 0);
+        assert.equal(items.length, 0);
         done();
       });
     });
@@ -750,11 +750,11 @@ describe('ParseMock', function(){
       const query = new Parse.Query(Item);
       query.lessThan("createdAt", new Date("2024-01-01T23:28:56.782Z"));
       query.find().then(function(items) {
-        assert(items.length == 1);
+        assert.equal(items.length, 1);
         const newQuery = new Parse.Query(Item);
         newQuery.greaterThan("createdAt", new Date());
         newQuery.find().then(function(moreItems) {
-          assert(moreItems.length === 0);
+          assert.equal(moreItems.length, 0);
           done();
         });
       });
@@ -766,10 +766,10 @@ describe('ParseMock', function(){
       const query = new Parse.Query(Item);
       query.lessThanOrEqualTo("price", 30);
       query.find().then(function(items) {
-        assert(items.length == 1);
+        assert.equal(items.length, 1);
         query.lessThanOrEqualTo("price", 20);
         query.find().then(function(moreItems) {
-          assert(moreItems.length === 0);
+          assert.equal(moreItems.length, 0);
           done();
         });
       });
@@ -781,10 +781,10 @@ describe('ParseMock', function(){
       const query = new Parse.Query(Item);
       query.greaterThan("price", 20);
       query.find().then(function(items) {
-        assert(items.length == 1);
+        assert.equal(items.length, 1);
         query.greaterThan("price", 50);
         query.find().then(function(moreItems) {
-          assert(moreItems.length === 0);
+          assert.equal(moreItems.length, 0);
           done();
         });
       });
@@ -796,10 +796,10 @@ describe('ParseMock', function(){
       const query = new Parse.Query(Item);
       query.greaterThanOrEqualTo("price", 30);
       query.find().then(function(items) {
-        assert(items.length == 1);
+        assert.equal(items.length, 1);
         query.greaterThanOrEqualTo("price", 50);
         query.find().then(function(moreItems) {
-          assert(moreItems.length === 0);
+          assert.equal(moreItems.length, 0);
           done();
         });
       });
@@ -812,10 +812,10 @@ describe('ParseMock', function(){
       query.greaterThan("price", 20);
       query.lessThan("price", 40);
       query.find().then(function(items) {
-        assert(items.length == 1);
+        assert.equal(items.length, 1);
         query.greaterThan("price", 30);
         query.find().then(function(moreItems) {
-          assert(moreItems.length === 0);
+          assert.equal(moreItems.length, 0);
           done();
         });
       });


### PR DESCRIPTION
Somehow I missed some of the assert to assert.equals changes in #35, so this pr has two commits:

1. 	5f198d7 cleans up the remaining assert to assert.equals.
2.	6ac4ec6 is a significant change to unit tests, which makes them behave properly in the face of async code and fixes: #30 by following this guide:  https://www.sitepoint.com/promises-in-javascript-unit-tests-the-definitive-guide/

     