### PR TITLE
Includes of invalid pointers in queries return undefined

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -292,7 +292,7 @@ function handleBatchRequest(method, path, data) {
     })
   })
 
-  return Parse.Promise.when(...getResults).then(function(results) {
+  return Parse.Promise.when.apply(null, getResults).then(function(results) {
     return respond(200, arguments);
   })
 }
@@ -511,7 +511,7 @@ function queryMatchesAfterIncluding(matches, includeClause) {
 function includePaths(object, pathsRemaining) {
   debugPrint('INCLUDE', {object, pathsRemaining})
   const path = pathsRemaining.shift();
-  const target = !object ? null : object[path];
+  const target = object && object[path];
 
   if (target) {
     if (Array.isArray(target)) {

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -511,7 +511,7 @@ function queryMatchesAfterIncluding(matches, includeClause) {
 function includePaths(object, pathsRemaining) {
   debugPrint('INCLUDE', {object, pathsRemaining})
   const path = pathsRemaining.shift();
-  const target = object[path];
+  const target = !object ? undefined : object[path];
 
   if (target) {
     if (Array.isArray(target)) {
@@ -538,6 +538,11 @@ function includePaths(object, pathsRemaining) {
 function fetchObjectByPointer(pointer) {
   const collection = getCollection(pointer.className);
   const storedItem = collection[pointer.objectId];
+
+  if (storedItem === undefined) {
+    return undefined;
+  }
+
   return Object.assign(
     { __type: "Object", className: pointer.className },
     _.cloneDeep(storedItem)

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -511,7 +511,7 @@ function queryMatchesAfterIncluding(matches, includeClause) {
 function includePaths(object, pathsRemaining) {
   debugPrint('INCLUDE', {object, pathsRemaining})
   const path = pathsRemaining.shift();
-  const target = !object ? undefined : object[path];
+  const target = !object ? null : object[path];
 
   if (target) {
     if (Array.isArray(target)) {

--- a/test/test.js
+++ b/test/test.js
@@ -268,6 +268,30 @@ describe('ParseMock', function(){
     });
   });
 
+  it("should return invalid pointers if they are not included", function() {
+    const item = new Item();
+    item.id = "ZZZZZZZZ";
+    return createStoreWithItemP(item).then(function(savedStore) {
+      const query = new Parse.Query(Store);
+      return query.first().then(function(result) {
+        assert.strictEqual(result.get("item").id, item.id);
+      });
+    });
+  });
+
+  it("should leave includes of invalid pointers undefined", function() {
+    const item = new Item();
+    item.id = "ZZZZZZZZ";
+    return createStoreWithItemP(item).then(function(savedStore) {
+      const query = new Parse.Query(Store);
+      query.include("item");
+      query.include("item.brand");
+      return query.first().then(function(result) {
+        assert.strictEqual(result.get("item"), undefined);
+      });
+    });
+  });
+
   it("should handle multiple nested includes", function() {
     var a1, a2, b, c;
     return Parse.Promise.when(


### PR DESCRIPTION
The Parse API returns undefined for a field that has an invalid pointer (i.e. a pointer where no object with that id exists anymore). I tested this behavior using the hosted parse service with parse cloud js sdk version 1.6.14.

Invalid pointers can easily happen if an object was removed but not all references were deleted.

This pull request provides two test cases for such a scenario and a fix to make those test cases succeed.