### PR TITLE
Initialize field before incrementing

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -188,6 +188,9 @@ const MASKED_UPDATE_OPS = new Set(["AddRelation", "RemoveRelation"]);
  */
 const UPDATE_OPERATORS = {
   Increment: function(key, value) {
+    if (this[key] === undefined) {
+      this[key] = 0;
+    }
     this[key] += value.amount;
   },
   Add: function(key, value) {

--- a/test/test.js
+++ b/test/test.js
@@ -270,6 +270,16 @@ describe('ParseMock', function(){
     });
   });
 
+  it('should increment a non-existent field', function() {
+    return createItemP(30).then(function(item) {
+      return item
+        .increment('foo')
+        .save();
+    }).then(function(item) {
+      assert.equal(item.get('foo'), 1);
+    });
+  });
+
   it('should support unset', function() {
     return createItemP(30).then(function(item) {
       item.unset("price");


### PR DESCRIPTION
If a field is undefined, increment returns NaN.  The Parse SDK will return 1.

This pr conforms ParseMockDB to the Parse SDK.