### PR TITLE
Fix response of POST/PUT requests in order to fix issue #44

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -593,6 +593,18 @@ function runHook(className, hookType, data) {
   return Parse.Promise.as(data);
 }
 
+function getChangedKeys(originalObject, updatedObject) {
+  if (originalObject === updatedObject) {
+    return [];
+  }
+  return _.reduce(updatedObject, (result, value, key) => {
+    if (!_.isEqual(originalObject[key], value)) {
+      result.push(key);
+    }
+    return result;
+  }, []);
+}
+
 /**
  * Handles a POST request (Parse.Object.save())
  */
@@ -601,7 +613,7 @@ function handlePostRequest(request) {
   const collection = getCollection(className);
 
   return runHook(className, 'beforeSave', request.data).then(result => {
-    const changedKeys = request.data !== result ? Object.keys(result) : [];
+    const changedKeys = getChangedKeys(request.data, result);
 
     const newId = _.uniqueId();
     const now = new Date();
@@ -655,7 +667,7 @@ function handlePutRequest(request) {
   const toOmit = ['createdAt', 'objectId'].concat(Array.from(getMask(className)));
 
   return runHook(className, 'beforeSave', updatedObject).then(result => {
-    const changedKeys = updatedObject !== result ? Object.keys(result) : [];
+    const changedKeys = getChangedKeys(updatedObject, result);
 
     collection[request.objectId] = updatedObject;
     const response = Object.assign(

--- a/test/test.js
+++ b/test/test.js
@@ -271,7 +271,7 @@ describe('ParseMock', () => {
       assert.equal(brand.get('items')[1].get('price'), 50);
       assert.equal(brand.get('items')[2].get('price'), 55);
 
-      brand.get('items')[0].set('price', 30);
+      brand.get('items')[2].set('price', 30);
       brand.set('name', 'foo');
       return brand.save();
     })

--- a/test/test.js
+++ b/test/test.js
@@ -252,6 +252,23 @@ describe('ParseMock', function(){
     });
   });
 
+  it.only('should save a nested item and return it with the save', function() {
+    return new Item().save().then(function(item) {
+      const brand = new Brand();
+      const item2 = new Item();
+      item2.id = "ABC";
+      brand.set("items", [item, item2]);
+      return brand.save();
+    }).then(function(brand) {
+      brand.get("items")[0].set("price", 30);
+      brand.set("name", "foo");
+      return brand.save();
+    }).then(function(sbrand) {
+      assert.equal(sbrand.get("items")[0].get("price"), 30);
+      assert.equal(sbrand.get("items")[1].get("price"), undefined);
+    });
+  });
+
   it('should support increment', function() {
     return createItemP(30).then(function(item) {
       item.increment("price", 5);

--- a/test/test.js
+++ b/test/test.js
@@ -256,20 +256,31 @@ describe('ParseMock', function(){
     return new Item().save({
       price: 45
     }).then(function(item0) {
-      return new Item().save().then(function(item) {
-        const brand = new Brand();
-        const item2 = new Item();
-        item2.id = item0.id; // create pointer to item0
-        brand.set("items", [item, item2]);
-        return brand.save();
-      })
+      return new Item().save({
+        price: 50
+      }).then(function(item2) {
+        return new Item({
+          price: 55
+        }).save().then(function(item3) {
+          const brand = new Brand();
+          const item1 = new Item();
+          item1.id = item0.id; // create pointer to item0
+          brand.set("items", [item1, item2, item3]);
+          return brand.save();
+        });
+      });
     }).then(function(brand) {
+      assert.equal(brand.get("items")[0].get("price"), undefined);
+      assert.equal(brand.get("items")[1].get("price"), 50);
+      assert.equal(brand.get("items")[2].get("price"), 55);
+
       brand.get("items")[0].set("price", 30);
       brand.set("name", "foo");
       return brand.save();
     }).then(function(sbrand) {
-      assert.equal(sbrand.get("items")[0].get("price"), 30);
-      assert.equal(sbrand.get("items")[1].get("price"), undefined);
+      assert.equal(sbrand.get("items")[0].get("price"), undefined);
+      assert.equal(sbrand.get("items")[1].get("price"), 50);
+      assert.equal(sbrand.get("items")[2].get("price"), 30);
     });
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -252,13 +252,17 @@ describe('ParseMock', function(){
     });
   });
 
-  it.only('should save a nested item and return it with the save', function() {
-    return new Item().save().then(function(item) {
-      const brand = new Brand();
-      const item2 = new Item();
-      item2.id = "ABC";
-      brand.set("items", [item, item2]);
-      return brand.save();
+  it('should save a nested item and return it with the save', function() {
+    return new Item().save({
+      price: 45
+    }).then(function(item0) {
+      return new Item().save().then(function(item) {
+        const brand = new Brand();
+        const item2 = new Item();
+        item2.id = item0.id; // create pointer to item0
+        brand.set("items", [item, item2]);
+        return brand.save();
+      })
     }).then(function(brand) {
       brand.get("items")[0].set("price", 30);
       brand.set("name", "foo");

--- a/test/test.js
+++ b/test/test.js
@@ -249,37 +249,38 @@ describe('ParseMock', () => {
     });
   });
 
-  it('should save a nested item and return it with the save', function() {
-    return new Item().save({
-      price: 45
-    }).then(function(item0) {
-      return new Item().save({
-        price: 50
-      }).then(function(item2) {
-        return new Item({
-          price: 55
-        }).save().then(function(item3) {
+  it('should save a nested item and return it with the save', () =>
+    new Item().save({
+      price: 45,
+    }).then((item0) =>
+      new Item().save({
+        price: 50,
+      }).then((item2) =>
+        new Item({
+          price: 55,
+        }).save().then((item3) => {
           const brand = new Brand();
           const item1 = new Item();
           item1.id = item0.id; // create pointer to item0
-          brand.set("items", [item1, item2, item3]);
+          brand.set('items', [item1, item2, item3]);
           return brand.save();
-        });
-      });
-    }).then(function(brand) {
-      assert.equal(brand.get("items")[0].get("price"), undefined);
-      assert.equal(brand.get("items")[1].get("price"), 50);
-      assert.equal(brand.get("items")[2].get("price"), 55);
+        })
+      )
+    ).then((brand) => {
+      assert.equal(brand.get('items')[0].get('price'), undefined);
+      assert.equal(brand.get('items')[1].get('price'), 50);
+      assert.equal(brand.get('items')[2].get('price'), 55);
 
-      brand.get("items")[0].set("price", 30);
-      brand.set("name", "foo");
+      brand.get('items')[0].set('price', 30);
+      brand.set('name', 'foo');
       return brand.save();
-    }).then(function(sbrand) {
-      assert.equal(sbrand.get("items")[0].get("price"), undefined);
-      assert.equal(sbrand.get("items")[1].get("price"), 50);
-      assert.equal(sbrand.get("items")[2].get("price"), 30);
-    });
-  });
+    })
+    .then((sbrand) => {
+      assert.equal(sbrand.get('items')[0].get('price'), undefined);
+      assert.equal(sbrand.get('items')[1].get('price'), 50);
+      assert.equal(sbrand.get('items')[2].get('price'), 30);
+    })
+  );
 
   it('should support increment', () =>
     createItemP(30).then((item) => {

--- a/test/test.js
+++ b/test/test.js
@@ -282,6 +282,45 @@ describe('ParseMock', () => {
     })
   );
 
+  it('should save a nested item and return it with the save even with a hook defined', () => {
+    ParseMockDB.registerHook('Brand', 'beforeSave', request => {
+      const object = request.object;
+      object.set('name', 'bar');
+      return Parse.Promise.as(object);
+    });
+
+    return new Item().save({
+      price: 45,
+    }).then((item0) =>
+      new Item().save({
+        price: 50,
+      }).then((item2) =>
+        new Item({
+          price: 55,
+        }).save().then((item3) => {
+          const brand = new Brand();
+          const item1 = new Item();
+          item1.id = item0.id; // create pointer to item0
+          brand.set('items', [item1, item2, item3]);
+          return brand.save();
+        })
+      )
+    ).then((brand) => {
+      assert.equal(brand.get('items')[0].get('price'), undefined);
+      assert.equal(brand.get('items')[1].get('price'), 50);
+      assert.equal(brand.get('items')[2].get('price'), 55);
+
+      brand.get('items')[2].set('price', 30);
+      brand.set('name', 'foo');
+      return brand.save();
+    })
+    .then((sbrand) => {
+      assert.equal(sbrand.get('items')[0].get('price'), undefined);
+      assert.equal(sbrand.get('items')[1].get('price'), 50);
+      assert.equal(sbrand.get('items')[2].get('price'), 30);
+    });
+  });
+
   it('should support increment', () =>
     createItemP(30).then((item) => {
       item.increment('price', 5);


### PR DESCRIPTION
It took me a while and some deep digging in the parse / parse-server sources but I finally found the problem that leads to the symptoms described in issue #44:

The parse js sdk expects the response from the `RESTController` to only contain certain fields. In particular these seem to be the following:

1. Fields that were changed in a `beforeSave` hook (see [`RestWrite#_updateResponseWithData` (line 951)](https://github.com/ParsePlatform/parse-server/blob/master/src/RestWrite.js)).
2. Fields that are changed via Ops (e.g. Add, AddUnique, Increment, Remove) (see [`sanitizeDatabaseResult` in `DatabaseController.js` line 260](https://github.com/ParsePlatform/parse-server/blob/master/src/Controllers/DatabaseController.js)).
3. `createdAt` and `objectId` in case of POST requests, `updatedAt` for PUT requests.

I am not a parse server developer so I don't have deep insight on why this is the way it is. However, I tried to emulate the behavior and managed to get all tests running as expected, including two new test cases concerning issue #44 that fail without this fix.

This PR fixes issue #44. 