### PR TITLE
Make parse a peer dependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "homepage": "https://github.com/HustleInc/parse-mockdb",
   "dependencies": {
     "lodash": "^4.0.0",
-    "parse": ">=1.6.0",
     "parse-shim": "^1.0.6"
   },
   "devDependencies": {
@@ -59,5 +58,8 @@
       "strict": "off",
       "prefer-rest-params": "off"
     }
+  },
+  "peerDependencies": {
+    "parse": "^1.9.0"
   }
 }


### PR DESCRIPTION
this fixes #3 

Once I did this and https://github.com/flovilmart/parse-image/pull/15 my parse initialize errors went away.  woooo