### PR TITLE
unit test for usage of Query.equalTo as "contains" in array-typed property

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -225,6 +225,22 @@ describe('ParseMock', () => {
     )
   );
 
+  it('should match a query that uses equalTo as contains constraint', () =>
+    createItemP(30)
+      .then((item) =>
+        new Parse.Object('Factory').save({
+          items: [item],
+        })
+        .then(savedComp => new Parse.Query('Factory')
+          .equalTo('items', item)
+          .find()
+          .then(results => {
+            assert.equal(results[0].id, savedComp.id);
+          })
+        )
+      )
+  );
+
   it('should save and find an item', () => {
     const item = new Item();
     item.set('price', 30);


### PR DESCRIPTION
When debugging a failing test case of our software I was in doubt if you library works as expected (which it does). So I added another test case that checks the usage of `Query.equalTo` as a contains in an array-typed property as seen in the first example [here](https://parseplatform.github.io/docs/js/guide/#queries-on-array-values).

The test case works fine but I thought you might want to add it to your test suite.