### PR TITLE
Add support for geo queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ParseMockDB.unMockDB(); // Un-mock the Parse RESTController
 ### Completeness
 
  - [x] Basic CRUD (save, destroy, fetch)
- - [x] Query operators ($exists, $in, $nin, $eq, $ne, $lt, $lte, $gt, $gte, $regex, $select, $inQuery, $all)
+ - [x] Query operators ($exists, $in, $nin, $eq, $ne, $lt, $lte, $gt, $gte, $regex, $select, $inQuery, $all, $nearSphere)
  - [x] Update operators (Increment, Add, AddUnique, Remove, Delete)
  - [x] Parse.Relation (AddRelation, RemoveRelation)
  - [x] Parse query dotted notation matching eg `{ "name.first": "Tyler" })`

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -280,6 +280,13 @@ function recursivelyMatch(className, where) {
   return _.cloneDeep(matches); // return copies instead of originals
 }
 
+// according to the js sdk api documentation parse uses the following radius of the earth
+const RADIUS_OF_EARTH_KM = 6371.0;
+const RADIUS_OF_EARCH_MILES = 3958.8;
+// the parse rest guide says that the maximum distance is 100 miles if no explicit maximum
+// is provided; here we already convert this distance into radians
+const DEFAULT_MAX_DISTANCE = 100 / RADIUS_OF_EARCH_MILES;
+
 /**
  * Operators for queries
  *
@@ -336,10 +343,8 @@ const QUERY_OPERATORS = {
     return undefined;
   },
   $nearSphere: (operand, value, maxDistanceInRadians) => {
-    // the parse rest guide says that the maximum distance is 100 miles if no explicit maximum
-    // is provided
-    if (_.isUndefined(maxDistanceInRadians) || _.isNull(maxDistanceInRadians)) {
-      maxDistanceInRadians = 100 / 3958.8;
+    if (_.isNil(maxDistanceInRadians)) {
+      maxDistanceInRadians = DEFAULT_MAX_DISTANCE;
     }
     return new Parse.GeoPoint(operand).radiansTo(new Parse.GeoPoint(value)) <= maxDistanceInRadians;
   },
@@ -379,12 +384,9 @@ function evaluateObject(object, whereParams, key) {
     if (whereParams) {
       maxDistanceInRadians = whereParams.$maxDistance || whereParams.$maxDistanceInRadians;
       if ('$maxDistanceInKilometers' in whereParams) {
-        // according to the js sdk api documentation parse uses a radius of the earth of 6371.0 km
-        maxDistanceInRadians = whereParams.$maxDistanceInKilometers / 6371.0;
+        maxDistanceInRadians = whereParams.$maxDistanceInKilometers / RADIUS_OF_EARTH_KM;
       } else if ('$maxDistanceInMiles' in whereParams) {
-        // according to the js sdk api documentation parse uses a radius of the earth of
-        // 3958.8 miles
-        maxDistanceInRadians = whereParams.$maxDistanceInMiles / 3958.8;
+        maxDistanceInRadians = whereParams.$maxDistanceInMiles / RADIUS_OF_EARCH_MILES;
       }
     }
 

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -282,10 +282,10 @@ function recursivelyMatch(className, where) {
 
 // according to the js sdk api documentation parse uses the following radius of the earth
 const RADIUS_OF_EARTH_KM = 6371.0;
-const RADIUS_OF_EARCH_MILES = 3958.8;
+const RADIUS_OF_EARTH_MILES = 3958.8;
 // the parse rest guide says that the maximum distance is 100 miles if no explicit maximum
 // is provided; here we already convert this distance into radians
-const DEFAULT_MAX_DISTANCE = 100 / RADIUS_OF_EARCH_MILES;
+const DEFAULT_MAX_DISTANCE = 100 / RADIUS_OF_EARTH_MILES;
 
 /**
  * Operators for queries
@@ -389,7 +389,7 @@ function evaluateObject(object, whereParams, key) {
       if ('$maxDistanceInKilometers' in whereParams) {
         args.maxDistanceInRadians = whereParams.$maxDistanceInKilometers / RADIUS_OF_EARTH_KM;
       } else if ('$maxDistanceInMiles' in whereParams) {
-        args.maxDistanceInRadians = whereParams.$maxDistanceInMiles / RADIUS_OF_EARCH_MILES;
+        args.maxDistanceInRadians = whereParams.$maxDistanceInMiles / RADIUS_OF_EARTH_MILES;
       }
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -349,6 +349,34 @@ describe('ParseMock', () => {
     })
   );
 
+  it('should match an item that is within a kilometer radius of a geo point', () =>
+    // the used two points are 133.4 km away according to http://www.movable-type.co.uk/scripts/latlong.html
+    new Item().save({
+      location: new Parse.GeoPoint(49, 7),
+    }).then(item =>
+      new Parse.Query(Item)
+        .withinKilometers('location', new Parse.GeoPoint(48, 8), 134)
+        .find()
+        .then(results => {
+          assert.equal(results[0].id, item.id);
+        })
+    )
+  );
+
+
+  it('should not match an item that is not within a kilometer radius of a geo point', () =>
+    // the used two points are 133.4 km away according to http://www.movable-type.co.uk/scripts/latlong.html
+    new Item().save({
+      location: new Parse.GeoPoint(49, 7),
+    }).then(() =>
+      new Parse.Query(Item)
+        .withinKilometers('location', new Parse.GeoPoint(48, 8), 133)
+        .find()
+    ).then(results => {
+      assert.equal(results.length, 0);
+    })
+  );
+
   it('should support unset', () =>
     createItemP(30).then((item) => {
       item.unset('price');

--- a/test/test.js
+++ b/test/test.js
@@ -363,7 +363,6 @@ describe('ParseMock', () => {
     )
   );
 
-
   it('should not match an item that is not within a kilometer radius of a geo point', () =>
     // the used two points are 133.4 km away according to http://www.movable-type.co.uk/scripts/latlong.html
     new Item().save({
@@ -375,6 +374,47 @@ describe('ParseMock', () => {
     ).then(results => {
       assert.equal(results.length, 0);
     })
+  );
+
+  xit('should sort matches of a geo query from nearest to furthest', () =>
+    // the used two points are 133.4 km away according to http://www.movable-type.co.uk/scripts/latlong.html
+    new Item().save({
+      location: new Parse.GeoPoint(49, 7),
+    }).then(item1 =>
+      new Item().save({
+        location: new Parse.GeoPoint(49, 8),
+      }).then(item2 =>
+        new Parse.Query(Item)
+          .withinKilometers('location', new Parse.GeoPoint(48, 8), 134)
+          .find()
+          .then(results => {
+            assert.equal(results[0].id, item2.id);
+            assert.equal(results[1].id, item1.id);
+          })
+      )
+    )
+  );
+
+  it('should use a custom order over ordering from nearest to furthest in a geo query', () =>
+    // the used two points are 133.4 km away according to http://www.movable-type.co.uk/scripts/latlong.html
+    new Item().save({
+      price: 10,
+      location: new Parse.GeoPoint(49, 7),
+    }).then(item1 =>
+      new Item().save({
+        price: 20,
+        location: new Parse.GeoPoint(49, 8),
+      }).then(item2 =>
+        new Parse.Query(Item)
+          .withinKilometers('location', new Parse.GeoPoint(48, 8), 134)
+          .ascending('price')
+          .find()
+          .then(results => {
+            assert.equal(results[0].id, item1.id);
+            assert.equal(results[1].id, item2.id);
+          })
+      )
+    )
   );
 
   it('should support unset', () =>


### PR DESCRIPTION
This PR adds support for geo queries (`withinKilometers`, `withinMiles`, `withinRadians`, `near`).

Tests are included as well.

Everything works except the ordering which should be from nearest to furthest [according to the docs](https://parseplatform.github.io/docs/rest/guide/#geo-queries) if no other ordering is used. I created tests for that but marked the failing one as pending because ordering seems to not be implemented so far, anyway.