### PR TITLE
Fix: 0 is not null/undefined bug

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -63,7 +63,7 @@ function objectsAreEqual(obj1, obj2) {
 
   // if any of those is null or undefined the other is not because
   // of above --> abort
-  if (!obj1 || !obj2) {
+  if (_.isNil(obj1) || _.isNil(obj2)) {
     return false;
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -246,6 +246,18 @@ describe('ParseMock', () => {
       )
   );
 
+  it.only('should match a query that uses equalTo as contains constraint with 0 as parameter', () =>
+    new Parse.Object('Factory').save({
+      items: [0, 1],
+    }).then(savedComp => new Parse.Query('Factory')
+      .equalTo('items', 0)
+      .find()
+      .then(results => {
+        assert.equal(results[0].id, savedComp.id);
+      })
+    )
+  );
+
   it('should save and find an item', () => {
     const item = new Item();
     item.set('price', 30);

--- a/test/test.js
+++ b/test/test.js
@@ -246,7 +246,7 @@ describe('ParseMock', () => {
       )
   );
 
-  it.only('should match a query that uses equalTo as contains constraint with 0 as parameter', () =>
+  it('should match a query that uses equalTo as contains constraint with 0 as parameter', () =>
     new Parse.Object('Factory').save({
       items: [0, 1],
     }).then(savedComp => new Parse.Query('Factory')


### PR DESCRIPTION
This PR fixes a bug that happened when trying to use `Query.equalTo('arrayKey', 0)`: It would never check the contains because `0` was treated as `false`.

A test case for this specific case is included.