### PR TITLE
Fixes for the equalTo query operator

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -376,7 +376,7 @@ function evaluateObject(object, whereParams, key) {
     }
   }
 
-  if (typeof whereParams === 'object') {
+  if (typeof whereParams === 'object' && !Array.isArray(whereParams)) {
     // Handle objects that actually represent scalar values
     if (isPointer(whereParams) || isDate(whereParams)) {
       return QUERY_OPERATORS.$eq.apply(null, [object[key], whereParams]);
@@ -447,8 +447,13 @@ function handleRequest(method, path, body) {
     data: body,
     objectId: explodedPath.shift(),
   };
-  // eslint-disable-next-line no-use-before-define
-  return HANDLERS[method](request);
+
+  try {
+    // eslint-disable-next-line no-use-before-define
+    return HANDLERS[method](request);
+  } catch (e) {
+    return Parse.Promise.error(e);
+  }
 }
 
 function respond(status, response) {

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -376,7 +376,7 @@ function evaluateObject(object, whereParams, key) {
     }
   }
 
-  if (typeof whereParams === 'object' && !Array.isArray(whereParams)) {
+  if (typeof whereParams === 'object' && !Array.isArray(whereParams) && whereParams) {
     // Handle objects that actually represent scalar values
     if (isPointer(whereParams) || isDate(whereParams)) {
       return QUERY_OPERATORS.$eq.apply(null, [object[key], whereParams]);

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -55,9 +55,19 @@ function deserializeQueryParam(param) {
  * (e.g. Pointer, Object)
  */
 function objectsAreEqual(obj1, obj2) {
+  // Always search through array on array columns
+  if (Array.isArray(obj1)) {
+    if (Array.isArray(obj2)) {
+      throw new Parse.Error(107, `You cannot use ${obj2} as a query parameter`);
+    } else {
+      return _.some(obj1, obj => objectsAreEqual(obj, obj2));
+    }
+  }
+
   // scalar values (including null/undefined)
-  // eslint-disable-next-line eqeqeq
-  if (obj1 == obj2) {
+  // Note: undefined equals null.
+  // For all other objects, strict equality is applied
+  if (obj1 === obj2 || (_.isNil(obj1) && _.isNil(obj2))) {
     return true;
   }
 
@@ -75,11 +85,6 @@ function objectsAreEqual(obj1, obj2) {
   // both pointers
   if (obj1.objectId !== undefined && obj1.objectId === obj2.objectId) {
     return true;
-  }
-
-  // search through array
-  if (Array.isArray(obj1)) {
-    return _.some(obj1, obj => objectsAreEqual(obj, obj2));
   }
 
   // both dates

--- a/test/test.js
+++ b/test/test.js
@@ -848,7 +848,7 @@ describe('ParseMock', () => {
     })
   );
 
-  xit('should handle an equalTo null query for an object without a null field', () =>
+  it('should handle an equalTo null query for an object without a null field', () =>
     createItemP(30).then((item) => {
       const store = new Store();
       store.set('item', item);

--- a/test/test.js
+++ b/test/test.js
@@ -258,6 +258,18 @@ describe('ParseMock', () => {
     )
   );
 
+  it('should not match a query that uses equalTo with [] as field value and 0 as parameter', () =>
+    new Parse.Object('Factory').save({
+      items: [],
+    }).then(() => new Parse.Query('Factory')
+      .equalTo('items', 0)
+      .find()
+      .then(results => {
+        assert.equal(results.length, 0);
+      })
+    )
+  );
+
   it('should save and find an item', () => {
     const item = new Item();
     item.set('price', 30);

--- a/test/test.js
+++ b/test/test.js
@@ -258,11 +258,35 @@ describe('ParseMock', () => {
     )
   );
 
-  it('should not match a query that uses equalTo with [] as field value and 0 as parameter', () =>
+  it('should not allow array values as equalTo parameter for array columns', () =>
+    new Parse.Object('Factory').save({
+      items: [0, 1],
+    }).then(() => new Parse.Query('Factory')
+      .equalTo('items', [0, 1])
+      .find()
+      .then(() => Parse.Promise.error(
+          new Error('Promise should have failed')),
+        () => Parse.Promise.as(true))
+    )
+  );
+
+  it('should not match objects with [] as field value and 0 as query parameter', () =>
     new Parse.Object('Factory').save({
       items: [],
     }).then(() => new Parse.Query('Factory')
       .equalTo('items', 0)
+      .find()
+      .then(results => {
+        assert.equal(results.length, 0);
+      })
+    )
+  );
+
+  it('should not match objects with null as field value and \'\' as query parameter', () =>
+    new Parse.Object('Factory').save({
+      name: null,
+    }).then(() => new Parse.Query('Factory')
+      .equalTo('items', '')
       .find()
       .then(results => {
         assert.equal(results.length, 0);


### PR DESCRIPTION
This PR fixes a couple of things with the equalTo query operator. All changes are backed by tests I did with a self-hosted parse db.

1. Equality is not like `==` in Javascript. Only `undefined` and `null` are treated as equal, for everything else strict equality (`===`) applies. For example, `''` is not equal to `null`.
2. Fixes equality when comparing a non-null field to `null`.
3. Array columns *always* use the contains operator.
4. Array columns do not allow equality matching against array values (fixing issue #52).

Each case has test cases backing it.