### PR TITLE
Fixes/relation class names

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -1351,6 +1351,7 @@ describe('ParseMock', () => {
       return query.find();
     }).then((items) => {
       assert.equal(items.length, 2);
+      assert.equal(items[0].className, 'Item');
       const relation = store.relation('items');
       relation.remove(items[1]);
       return store.save();


### PR DESCRIPTION
Fixes a bug where `classNames` are not exposed when querying relation objects.