### PR TITLE
Fix for queries with ascending/descending order specifed

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -559,6 +559,34 @@ function queryMatchesAfterIncluding(matches, includeClause) {
 }
 
 /**
+ * Sort query results if necessary
+ */
+function sortQueryresults(matches, order) {
+  // sort order
+  let sortKey = order;
+  let sortDir = 1;
+  const sortArray = [];
+  if (order.charAt(0) === '-') {
+    sortKey = order.substring(1);
+    sortDir = -1;
+  }
+  matches.forEach(item => {
+    const keyVal = item[sortKey];
+    let sortVal = keyVal;
+
+    // Attempt to handle dates, numbers and strings
+    const keyDate = new Date(keyVal);
+    if (keyDate !== 'Invalid Date' && !isNaN(keyDate)) {
+      sortVal = keyDate.getTime();
+    }
+    sortArray.push({ dataItem: item, sortVal });
+  });
+  sortArray.sort((a, b) => (a.sortVal - b.sortVal) * sortDir);
+
+  return sortArray.map(sortItem => sortItem.dataItem);
+}
+
+/**
  * Handles a GET request (Parse.Query.find(), get(), first(), Parse.Object.fetch())
  */
 function handleGetRequest(request) {
@@ -606,6 +634,11 @@ function handleGetRequest(request) {
       match.updatedAt = match.updatedAt.toJSON();
     }
   });
+
+  // sort results if necessary
+  if (data.order && data.order.length > 0 && matches.length > 0) {
+    matches = sortQueryresults(matches, data.order);
+  }
 
   const limit = data.limit || DEFAULT_LIMIT;
   const startIndex = data.skip || 0;

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -581,7 +581,7 @@ function sortQueryresults(matches, order) {
     }
     sortArray.push({ dataItem: item, sortVal });
   });
-  sortArray.sort((a, b) => (a.sortVal - b.sortVal) * sortDir);
+  sortArray.sort((a, b) => ((a.sortVal > b.sortVal) ? 1 : -1) * sortDir);
 
   return sortArray.map(sortItem => sortItem.dataItem);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -509,6 +509,29 @@ describe('ParseMock', () => {
     )
   );
 
+  it('should use a descending order for text queries', () =>
+      new Item().save({
+        moniker: 'Meerkat',
+      }).then(item1 =>
+          new Item().save({
+            moniker: 'Aardvaark',
+          }).then(item2 =>
+          new Item().save({
+            moniker: 'Zebra',
+          }).then(item3 =>
+          new Parse.Query(Item)
+            .descending('moniker')
+            .find()
+            .then(results => {
+              assert.equal(results[0].id, item3.id);
+              assert.equal(results[1].id, item1.id);
+              assert.equal(results[2].id, item2.id);
+            })
+        )
+      )
+    )
+  );
+
   it('should support unset', () =>
     createItemP(30).then((item) => {
       item.unset('price');

--- a/test/test.js
+++ b/test/test.js
@@ -487,7 +487,6 @@ describe('ParseMock', () => {
   );
 
   it('should use a descending order for query', () =>
-      // the used two points are 133.4 km away according to http://www.movable-type.co.uk/scripts/latlong.html
       new Item().save({
         price: 21,
       }).then(item1 =>

--- a/test/test.js
+++ b/test/test.js
@@ -467,7 +467,7 @@ describe('ParseMock', () => {
   it('should use a custom order over ordering from nearest to furthest in a geo query', () =>
     // the used two points are 133.4 km away according to http://www.movable-type.co.uk/scripts/latlong.html
     new Item().save({
-      price: 10,
+      price: 21,
       location: new Parse.GeoPoint(49, 7),
     }).then(item1 =>
       new Item().save({
@@ -479,9 +479,33 @@ describe('ParseMock', () => {
           .ascending('price')
           .find()
           .then(results => {
-            assert.equal(results[0].id, item1.id);
-            assert.equal(results[1].id, item2.id);
+            assert.equal(results[0].id, item2.id);
+            assert.equal(results[1].id, item1.id);
           })
+      )
+    )
+  );
+
+  it('should use a descending order for query', () =>
+      // the used two points are 133.4 km away according to http://www.movable-type.co.uk/scripts/latlong.html
+      new Item().save({
+        price: 21,
+      }).then(item1 =>
+          new Item().save({
+            price: 25,
+          }).then(item2 =>
+          new Item().save({
+            price: 20,
+          }).then(item3 =>
+          new Parse.Query(Item)
+            .descending('price')
+            .find()
+            .then(results => {
+              assert.equal(results[0].id, item2.id);
+              assert.equal(results[1].id, item1.id);
+              assert.equal(results[2].id, item3.id);
+            })
+        )
       )
     )
   );


### PR DESCRIPTION
Added array sort function to honour queries which have ascending/descending specified.