### PR TITLE
Fetch remove relations

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -574,7 +574,13 @@ function handleGetRequest(request) {
         error: 'object not found for update',
       }));
     }
-    const match = _.cloneDeep(currentObject);
+    let match = _.cloneDeep(currentObject);
+
+    if (match) {
+      const toOmit = Array.from(getMask(className));
+      match = _.omit(match, toOmit);
+    }
+
     return Parse.Promise.as(respond(200, match));
   }
   const data = request.data;

--- a/test/test.js
+++ b/test/test.js
@@ -1345,11 +1345,19 @@ describe('ParseMock', () => {
       relation.add(paperTowels);
       relation.add(toothPaste);
       return store.save();
-    }).then(() => {
+    })
+    .then(() => store.fetch()
+    ).then((fetchedStore) => {
+      const fetchRelation = fetchedStore.relation('items');
+      return fetchRelation.query().count();
+    })
+    .then((itemCount) => {
+      assert.equal(itemCount, 2);
       const relation = store.relation('items');
       const query = relation.query();
       return query.find();
-    }).then((items) => {
+    })
+    .then((items) => {
       assert.equal(items.length, 2);
       assert.equal(items[0].className, 'Item');
       const relation = store.relation('items');


### PR DESCRIPTION
Fixed a bug where fetch requests were not removing relation data, resulting in the error:-
`Error: Called relation() on non-relation field items`

Updated tests to highlight the bug/fix