### PR TITLE
Support for multiple sort keys

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -562,28 +562,17 @@ function queryMatchesAfterIncluding(matches, includeClause) {
  * Sort query results if necessary
  */
 function sortQueryresults(matches, order) {
-  // sort order
-  let sortKey = order;
-  let sortDir = 1;
-  const sortArray = [];
-  if (order.charAt(0) === '-') {
-    sortKey = order.substring(1);
-    sortDir = -1;
-  }
-  matches.forEach(item => {
-    const keyVal = item[sortKey];
-    let sortVal = keyVal;
-
-    // Attempt to handle dates, numbers and strings
-    const keyDate = new Date(keyVal);
-    if (keyDate !== 'Invalid Date' && !isNaN(keyDate)) {
-      sortVal = keyDate.getTime();
+  const orderArray = order.split(',').map(k => {
+    if (k.charAt(0) === '-') {
+      return [k.substring(1), 'desc'];
     }
-    sortArray.push({ dataItem: item, sortVal });
+    return [k, 'asc'];
   });
-  sortArray.sort((a, b) => ((a.sortVal > b.sortVal) ? 1 : -1) * sortDir);
 
-  return sortArray.map(sortItem => sortItem.dataItem);
+  const keys = orderArray.map(_.first);
+  const orders = orderArray.map(_.last);
+
+  return _.orderBy(matches, keys, orders);
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -532,6 +532,33 @@ describe('ParseMock', () => {
     )
   );
 
+  it('should support multiple sorting parameters', () =>
+    new Item().save({
+      active: true,
+      price: 20,
+    }).then(item1 =>
+      new Item().save({
+        active: true,
+        price: 21,
+      }).then(item2 =>
+        new Item().save({
+          active: false,
+          price: 20,
+        }).then(item3 =>
+          new Parse.Query(Item)
+            .descending('active')
+            .addAscending('price')
+            .find()
+            .then(results => {
+              assert.equal(results[0].id, item1.id);
+              assert.equal(results[1].id, item2.id);
+              assert.equal(results[2].id, item3.id);
+            })
+        )
+      )
+    )
+  );
+
   it('should support unset', () =>
     createItemP(30).then((item) => {
       item.unset('price');


### PR DESCRIPTION
Parse allows adding multiple sort keys to a query (see test case). This PR adds support for this.