### PR TITLE
Fix addUnique with non-scalar values

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -134,7 +134,7 @@ const UPDATE_OPERATORS = {
     ensureArray(object, key);
     const array = object[key];
     value.objects.forEach(el => {
-      if (array.indexOf(el) === -1) {
+      if (!_.some(array, e => objectsAreEqual(e, el))) {
         array.push(el);
       }
     });

--- a/test/test.js
+++ b/test/test.js
@@ -630,6 +630,44 @@ describe('ParseMock', () => {
     })
   );
 
+  it('should support addUnique with parse objects', () =>
+    new Item().save().then(i =>
+      new Brand()
+        .save()
+        .then(b => {
+          b.addUnique('items', i);
+          return b.save();
+        })
+        .then(b => {
+          b.addUnique('items', i);
+          return b.save();
+        })
+        .then(b => b.fetch())
+        .then(b => {
+          assert.equal(b.get('items').length, 1);
+          assert.equal(b.get('items')[0].id, i.id);
+        })
+    )
+  );
+
+  it('should support addUnique with dates', () =>
+    new Item()
+      .save()
+      .then(i => {
+        i.addUnique('dates', new Date(5));
+        return i.save();
+      })
+      .then(i => {
+        i.addUnique('dates', new Date(5));
+        return i.save();
+      })
+      .then(i => i.fetch())
+      .then(i => {
+        assert.equal(i.get('dates').length, 1);
+        assert.equal(i.get('dates')[0].getTime(), 5);
+      })
+  );
+
   it('should support remove', () =>
     createItemP(30).then((item) => {
       item.add('languages', 'JS');


### PR DESCRIPTION
`addUnique` would not detect duplicate non-scalar values like Dates or parse objects.

This PR add tests and fixes this behavior.