### PR TITLE
Fix: addRelation should not produce duplicates

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -153,7 +153,9 @@ const UPDATE_OPERATORS = {
     ensureArray(object, key);
     const relation = object[key];
     value.objects.forEach(pointer => {
-      relation.push(pointer);
+      if (!_.some(relation, e => objectsAreEqual(e, pointer))) {
+        relation.push(pointer);
+      }
     });
   },
   RemoveRelation: (object, key, value) => {

--- a/test/test.js
+++ b/test/test.js
@@ -1485,7 +1485,7 @@ describe('ParseMock', () => {
     });
   });
 
-  it.only('should not have duplicates in relations', () =>
+  it('should not have duplicates in relations', () =>
     new Item().save().then(i =>
       new Brand()
         .save()

--- a/test/test.js
+++ b/test/test.js
@@ -1485,6 +1485,28 @@ describe('ParseMock', () => {
     });
   });
 
+  it.only('should not have duplicates in relations', () =>
+    new Item().save().then(i =>
+      new Brand()
+        .save()
+        .then(b => {
+          b.relation('items').add(Item.createWithoutData(i.id));
+          b.relation('items').add(Item.createWithoutData(i.id));
+          return b.save();
+        })
+        .then(b => {
+          const bPrime = Brand.createWithoutData(b.id);
+          bPrime.relation('items').add(Item.createWithoutData(i.id));
+          return bPrime.save();
+        })
+        .then(b => Brand.createWithoutData(b.id).relation('items').query().find())
+        .then(items => {
+          assert.equal(items.length, 1);
+          assert.equal(items[0].id, i.id);
+        })
+    )
+  );
+
   it('should handle a direct query on a relation field', () => {
     const store = new Store({ name: 'store 1' });
     const store2 = new Store({ name: 'store 2' });

--- a/test/test.js
+++ b/test/test.js
@@ -1490,16 +1490,17 @@ describe('ParseMock', () => {
       new Brand()
         .save()
         .then(b => {
-          b.relation('items').add(Item.createWithoutData(i.id));
-          b.relation('items').add(Item.createWithoutData(i.id));
+          b.relation('items').add(i);
+          b.relation('items').add(i);
           return b.save();
         })
+        .then(b => b.fetch())
         .then(b => {
-          const bPrime = Brand.createWithoutData(b.id);
-          bPrime.relation('items').add(Item.createWithoutData(i.id));
-          return bPrime.save();
+          b.relation('items').add(i);
+          return b.save();
         })
-        .then(b => Brand.createWithoutData(b.id).relation('items').query().find())
+        .then(b => b.fetch())
+        .then(b => b.relation('items').query().find())
         .then(items => {
           assert.equal(items.length, 1);
           assert.equal(items[0].id, i.id);


### PR DESCRIPTION
Parse relations are duplicate free. This PR makes parse-mockdb resemble this behavior. A test case is included.