### PR TITLE
Ensure Aftersave hook receives valid object

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -712,6 +712,7 @@ function handlePostRequest(request) {
   const className = request.className;
   const collection = getCollection(className);
 
+  let response;
   return runHook(className, 'beforeSave', request.data).then(result => {
     const changedKeys = getChangedKeys(request.data, result);
 
@@ -731,13 +732,13 @@ function handlePostRequest(request) {
 
     collection[newId] = newObject;
 
-    const response = Object.assign(
+    response = Object.assign(
       _.cloneDeep(_.omit(_.pick(result, toPick), toOmit)),
       { objectId: newId, createdAt: result.createdAt.toJSON() }
     );
 
     return Parse.Promise.as(respond(201, response));
-  }).then(result => runHook(className, 'afterSave', request.data).then(() => result));
+  }).then(result => runHook(className, 'afterSave', response).then(() => result));
 }
 
 function handlePutRequest(request) {
@@ -766,16 +767,17 @@ function handlePutRequest(request) {
   applyOps(updatedObject, ops, className);
   const toOmit = ['createdAt', 'objectId'].concat(Array.from(getMask(className)));
 
+  let response;
   return runHook(className, 'beforeSave', updatedObject).then(result => {
     const changedKeys = getChangedKeys(updatedObject, result);
 
     collection[request.objectId] = updatedObject;
-    const response = Object.assign(
+    response = Object.assign(
       _.cloneDeep(_.omit(_.pick(result, Object.keys(ops).concat(changedKeys)), toOmit)),
       { updatedAt: now }
     );
     return Parse.Promise.as(respond(200, response));
-  }).then(result => runHook(className, 'afterSave', updatedObject).then(() => result));
+  }).then(result => runHook(className, 'afterSave', response).then(() => result));
 }
 
 function handleDeleteRequest(request) {


### PR DESCRIPTION
Description:

This commit is a follow-up to #65 (Commit b42ed240d10a25),
which added support for Aftersave hooks.

There was a flaw in the implementation where the saved
Parse object that was passed into the Aftersave hook
did not have the `createdAt`, `updatedAt`, and `id`
properties.

The solution was to pass the response object to the after-
-save hook, as the missing props were only assigned to
that object.

This commit also resolves issue #67 as the `isNew()` 
method relies on the presence of the `id` property.

Tests:

- add test that ensures that the object passed into the aftersave
   hook has the `createdAt`, `updatedAt`, and `id` properties.

- modify existing test that wrongly asserted that an object would 
  not be saved due to an error in the aftersave hook has been
  changed to assert that the object was saved.