### PR TITLE
afterSave hook fixes

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -673,7 +673,11 @@ function runHook(className, hookType, data) {
   let hook = getHook(className, hookType);
   if (hook) {
     const modelData = Object.assign({}, data, { className });
-    const model = Parse.Object.fromJSON(modelData);
+    const modelJSON = _.mapValues(modelData,
+      // Convert dates into JSON loadable representations
+      value => ((value instanceof Date) ? value.toJSON() : value)
+    );
+    const model = Parse.Object.fromJSON(modelJSON);
     hook = hook.bind(model);
 
     // TODO Stub out Parse.Cloud.useMasterKey() so that we can report the correct 'master'
@@ -712,7 +716,7 @@ function handlePostRequest(request) {
   const className = request.className;
   const collection = getCollection(className);
 
-  let response;
+  let newObject;
   return runHook(className, 'beforeSave', request.data).then(result => {
     const changedKeys = getChangedKeys(request.data, result);
 
@@ -721,7 +725,7 @@ function handlePostRequest(request) {
 
     const ops = extractOps(result);
 
-    const newObject = Object.assign(
+    newObject = Object.assign(
       result,
       { objectId: newId, createdAt: now, updatedAt: now }
     );
@@ -732,13 +736,16 @@ function handlePostRequest(request) {
 
     collection[newId] = newObject;
 
-    response = Object.assign(
+    const response = Object.assign(
       _.cloneDeep(_.omit(_.pick(result, toPick), toOmit)),
       { objectId: newId, createdAt: result.createdAt.toJSON() }
     );
 
     return Parse.Promise.as(respond(201, response));
-  }).then(result => runHook(className, 'afterSave', response).then(() => result));
+  }).then((result) => {
+    runHook(className, 'afterSave', newObject);
+    return result;
+  });
 }
 
 function handlePutRequest(request) {
@@ -767,17 +774,19 @@ function handlePutRequest(request) {
   applyOps(updatedObject, ops, className);
   const toOmit = ['createdAt', 'objectId'].concat(Array.from(getMask(className)));
 
-  let response;
   return runHook(className, 'beforeSave', updatedObject).then(result => {
     const changedKeys = getChangedKeys(updatedObject, result);
 
     collection[request.objectId] = updatedObject;
-    response = Object.assign(
+    const response = Object.assign(
       _.cloneDeep(_.omit(_.pick(result, Object.keys(ops).concat(changedKeys)), toOmit)),
       { updatedAt: now }
     );
     return Parse.Promise.as(respond(200, response));
-  }).then(result => runHook(className, 'afterSave', response).then(() => result));
+  }).then((result) => {
+    runHook(className, 'afterSave', updatedObject);
+    return result;
+  });
 }
 
 function handleDeleteRequest(request) {

--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -780,7 +780,7 @@ function handlePutRequest(request) {
     collection[request.objectId] = updatedObject;
     const response = Object.assign(
       _.cloneDeep(_.omit(_.pick(result, Object.keys(ops).concat(changedKeys)), toOmit)),
-      { updatedAt: now }
+      { updatedAt: now.toJSON() }
     );
     return Parse.Promise.as(respond(200, response));
   }).then((result) => {

--- a/test/test.js
+++ b/test/test.js
@@ -166,24 +166,11 @@ function behavesLikeParseObjectOnBeforeDelete(typeName, ParseObjectOrUserSubclas
 
 function behavesLikeParseObjectOnAfterSave(typeName, ParseObjectOrUserSubclass) {
   context('when object has afterSave hook registered', () => {
-    const errorMessage = 'Error in afterSave hook test';
-    let didAfterSave = false;
+    let didAfterSave;
+    let objectInAfterSave;
     function afterSavePromise(request) {
-      if (request.object.get('error')) {
-        return Parse.Promise.error(errorMessage);
-      }
       didAfterSave = true;
-      return Parse.Promise.as();
-    }
-
-    let objectInAfterSave = {};
-    function afterSaveHasCreatedAt(request) {
-      didAfterSave = true;
-      objectInAfterSave = {
-        createdAt: request.object.get('createdAt'),
-        updatedAt: request.object.get('updatedAt'),
-        id: request.object.id,
-      };
+      objectInAfterSave = request.object;
       return Parse.Promise.as();
     }
 
@@ -192,43 +179,51 @@ function behavesLikeParseObjectOnAfterSave(typeName, ParseObjectOrUserSubclass) 
       objectInAfterSave = {};
     });
 
-    it('runs the hook after saving the model and persists the object', () => {
+    it('runs the hook after saving the model and persisting the object', () => {
       ParseMockDB.registerHook(typeName, 'afterSave', afterSavePromise);
-
       const object = new ParseObjectOrUserSubclass();
-      assert(!object.has('cool'));
-
-      return object.save().then((savedObject) => {
-        assert(!savedObject.has('cool'));
-        assert(didAfterSave);
-      });
+      return object.save().then(() => assert(didAfterSave));
     });
 
-    it('object is saved even if there was a problem', () => {
+    it("get all the object's attributes during the afterSave hook", () => {
       ParseMockDB.registerHook(typeName, 'afterSave', afterSavePromise);
-
-      const object = new ParseObjectOrUserSubclass({ error: true });
-      return object.save();
-    });
-
-    it('object has the complete object during aftersave', () => {
-      ParseMockDB.registerHook(typeName, 'afterSave', afterSaveHasCreatedAt);
-
-      const object = new ParseObjectOrUserSubclass();
+      const object = new ParseObjectOrUserSubclass({ name: 'abc' });
       return object.save().then((savedObject) => {
         assert(didAfterSave);
+
         assert.equal(
-          objectInAfterSave.createdAt.getTime(),
+          objectInAfterSave.get('createdAt').getTime(),
           savedObject.get('createdAt').getTime()
         );
+
         assert.equal(
-          objectInAfterSave.updatedAt.getTime(),
+          objectInAfterSave.get('updatedAt').getTime(),
           savedObject.get('updatedAt').getTime()
         );
+
         assert.equal(
           objectInAfterSave.id,
           savedObject.id
         );
+
+        assert.equal(
+          objectInAfterSave.get('name'),
+          savedObject.get('name')
+        );
+      });
+    });
+
+    context('when the afterSave hook hits an error', () => {
+      beforeEach(() => {
+        const badHook = () => Parse.Promise.reject(new Error('Something went wrong'));
+        ParseMockDB.registerHook(typeName, 'afterSave', badHook);
+      });
+
+      it('still saves the object', () => {
+        const object = new ParseObjectOrUserSubclass();
+        return object.save().then((savedObject) => {
+          assert(!!savedObject.id);
+        });
       });
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -1327,7 +1327,8 @@ describe('ParseMock', () => {
         store.set('item', item2);
         return store.save().then((returnedStore) => {
           assert(returnedStore.has('item'));
-          assert(returnedStore.get('item').get('price') === 10);
+          assert.equal(returnedStore.get('item').get('price'), 10);
+          assert(returnedStore.get('updatedAt') instanceof Date);
         });
       })
     )


### PR DESCRIPTION
In 78296a0, a bug was introduced where we would invoke afterSave
hooks with only the subset of fields that was being directly returned
from the invocation to `save()`. This doesn't match Parse Server's
behavior, or the tests.

Of note: commit 78296a0 actually broke tests that were originally
written in commit b42ed24 (it "rejects the save if there is a
problem"), because the "error" field wasn't being passed down into the
after save hook, preventing it from triggering the error state. The test
was updated so that it would pass (it "...is saved even if there was a
problem").

Because this new test does describe how I expect Parse Server to behave,
I've updated MockDB to match this specification instead of spuriously
passing. I also did a little bit of cleanup on the tests themselves, to
simplify and read more nicely.

While testing this, I also uncovered a bug around `updatedAt` timestamps not
being returned faithfully, which I've also corrected.