### PR TITLE
Add code from NPM v0.2.1

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -693,7 +693,7 @@ function runHook(className, hookType, data) {
         objectToProceedWith = beforeSaveOverrideValue.toJSON();
       }
 
-      return Parse.Promise.as(_.omit(objectToProceedWith, 'ACL'));
+      return Parse.Promise.as(objectToProceedWith);
     });
   }
   return Parse.Promise.as(data);


### PR DESCRIPTION
The version of parse-mockdb at v0.2.1 has this line of code which gets rid of the behavior of the library from omitting acl fields from being passed between hooks. This PR allows consumers to switch freely between the NPM release and the Github release without issues.