### PR TITLE
Add ability to mock request.user

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -21,6 +21,7 @@ let outOfBandResults = null;
 
 let defaultController = null;
 let mocked = false;
+let user = null;
 
 function debugPrint(prefix, object) {
   if (CONFIG.DEBUG) {
@@ -222,12 +223,16 @@ function getHook(className, hookType) {
   return undefined;
 }
 
+function mockUser(_user) {
+  user = _user;
+}
+
 function makeRequestObject(model, useMasterKey) {
   return {
     installationId: 'parse-mockdb',
     master: useMasterKey,
     object: model,
-    user: "ParseMockDB doesn't define request.user.",
+    user,
   };
 }
 
@@ -868,6 +873,7 @@ Parse.MockDB = {
   cleanUp,
   promiseResultSync,
   registerHook,
+  mockUser,
 };
 
 module.exports = Parse.MockDB;


### PR DESCRIPTION
Currently, we set the user to the string `"ParseMockDB doesn't define request.user." `
This PR allows tests to pass in a mock user object which will be returned by `makeRequestObject()` instead of the above string. Additionally, if the test doesn't provide a mock user, we default to `null`. 
A `null` user shouldn't affect tests that don't care about the user being set. Tests that do care about the user being set can pass a mock user object that meets their need.