### PR TITLE
Check if `where` is undefined in queryFilter()

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -443,7 +443,7 @@ function evaluateObject(object, whereParams, key) {
  * Returns a function that filters query matches on a where clause
  */
 function queryFilter(where) {
-  if (where.$or) {
+  if (where && where.$or) {
     return object =>
       _.reduce(where.$or, (result, subclause) => result ||
         queryFilter(subclause)(object), false);


### PR DESCRIPTION
When running `Parse.Schema.all()`, `queryFilter` was hit with `where` being undefined. Simply check if `where` is truthy before checking `where.$or`.