### PR TITLE
Provide request.original object to afterSave hook as per real Parse Server behaviour

### DIFF
--- a/src/parse-mockdb.js
+++ b/src/parse-mockdb.js
@@ -693,7 +693,7 @@ function runHook(className, hookType, data, originalData) {
       );
       return Parse.Object.fromJSON(modelJSON);
     };
-    const model = hydrate(data, className); //  TODO: remove this
+    const model = hydrate(data);
     hook = hook.bind(model);
 
     const original = (originalData !== undefined) ? hydrate(originalData) : undefined;

--- a/test/original_in_aftersave/SCENARIO.md
+++ b/test/original_in_aftersave/SCENARIO.md
@@ -1,0 +1,111 @@
+### Problem
+
+The `afterSave` hook in **Parse MockDB** behaves differently to a
+real Parse Server (v4.4.0 at time of writing).
+
+In a real server, the `afterSave` hook will provide the original object
+from before the save as `request.original`, as well as the saved object
+in `request.object` as expected. In other words, it should provide the
+same objects on the `request` object as you would see in `beforeSave`.
+
+Thus, any cloud code which relies on using this information to perform
+certain actions when particular data has changed isn't able to be unit
+tested via Parse MockDB.
+
+### Testing
+
+- Cloud Code is here: [`main.js`](./main.js)
+- Client-side simulation script is here: [`test_context.js`](./test_context.js)
+
+The cloud code just logs out the `request.original` and `request.object`
+in the `beforeSave` hook and the `afterSave` hook.
+
+The test script just creates an object and then updates it.
+
+Run the test Parse Server via Docker as below:
+
+```bash
+$ docker run --rm --name test-mongo -d mongo && \
+> docker run --rm --name test-parse-server -p 1337:1337 -e VERBOSE=0 \
+>            -v $(pwd):/parse-server/cloud --link test-mongo parseplatform/parse-server \
+>                --appId test-app --masterKey "M@stErK3y" \
+>                --databaseURI "mongodb://test-mongo/test" --cloud /parse-server/cloud/main.js
+...
+
+[1] parse-server running on http://localhost:1337/parse
+...
+```
+
+After running the test script in a separate terminal:
+
+```bash
+$ node test_context.js 
+Created { foo: 'bar',
+  createdAt: '2020-11-09T07:42:11.956Z',
+  updatedAt: '2020-11-09T07:42:11.956Z',
+  objectId: 'zwZdxCML9F' }
+Updated { foo: 'baaaah',
+  createdAt: '2020-11-09T07:42:11.956Z',
+  updatedAt: '2020-11-09T07:42:12.043Z',
+  objectId: 'zwZdxCML9F' }
+```
+
+You will see this in the server logs (split into two
+chunks: (1) create then (2) update):
+
+**Create**
+```
+BEFORE: undefined -> { foo: 'bar' }
+info: beforeSave triggered for Thing for user undefined:
+  Input: {"foo":"bar"}
+  Result: {"object":{"foo":"bar"}} {"className":"Thing","triggerType":"beforeSave"}
+AFTER: undefined -> {
+  foo: 'bar',
+  createdAt: '2020-11-09T07:42:11.956Z',
+  updatedAt: '2020-11-09T07:42:11.956Z',
+  objectId: 'zwZdxCML9F'
+}
+info: afterSave triggered for Thing for user undefined:
+  Input: {"foo":"bar","createdAt":"2020-11-09T07:42:11.956Z","updatedAt":"2020-11-09T07:42:11.956Z","objectId":"zwZdxCML9F"} {"className":"Thing","triggerType":"afterSave"}
+info: afterSave triggered for Thing for user undefined:
+  Input: {"foo":"bar","createdAt":"2020-11-09T07:42:11.956Z","updatedAt":"2020-11-09T07:42:11.956Z","objectId":"zwZdxCML9F"}
+  Result: undefined {"className":"Thing","triggerType":"afterSave"}
+```
+
+**Update**
+```
+BEFORE: {
+  foo: 'bar',
+  createdAt: '2020-11-09T07:42:11.956Z',
+  updatedAt: '2020-11-09T07:42:11.956Z',
+  objectId: 'zwZdxCML9F'
+} -> {
+  foo: 'baaaah',
+  createdAt: '2020-11-09T07:42:11.956Z',
+  updatedAt: '2020-11-09T07:42:11.956Z',
+  objectId: 'zwZdxCML9F'
+}
+info: beforeSave triggered for Thing for user undefined:
+  Input: {"foo":"baaaah","createdAt":"2020-11-09T07:42:11.956Z","updatedAt":"2020-11-09T07:42:11.956Z","objectId":"zwZdxCML9F"}
+  Result: {"object":{"foo":"baaaah"}} {"className":"Thing","triggerType":"beforeSave"}
+AFTER: {
+  foo: 'bar',
+  createdAt: '2020-11-09T07:42:11.956Z',
+  updatedAt: '2020-11-09T07:42:11.956Z',
+  objectId: 'zwZdxCML9F'
+} -> {
+  foo: 'baaaah',
+  createdAt: '2020-11-09T07:42:11.956Z',
+  updatedAt: '2020-11-09T07:42:12.043Z',
+  objectId: 'zwZdxCML9F'
+}
+info: afterSave triggered for Thing for user undefined:
+  Input: {"foo":"baaaah","createdAt":"2020-11-09T07:42:11.956Z","updatedAt":"2020-11-09T07:42:12.043Z","objectId":"zwZdxCML9F"} {"className":"Thing","triggerType":"afterSave"}
+info: afterSave triggered for Thing for user undefined:
+  Input: {"foo":"baaaah","createdAt":"2020-11-09T07:42:11.956Z","updatedAt":"2020-11-09T07:42:12.043Z","objectId":"zwZdxCML9F"}
+  Result: undefined {"className":"Thing","triggerType":"afterSave"}
+```
+
+As you can see in the final part of the logs above, the
+original object and the saved object are sent through to
+`afterSave`.

--- a/test/original_in_aftersave/main.js
+++ b/test/original_in_aftersave/main.js
@@ -1,0 +1,11 @@
+/* global Parse */
+
+Parse.Cloud.beforeSave('Thing', (req /* , res */) => {
+  console.log('BEFORE:',
+    req.original !== undefined ? req.original.toJSON() : undefined, '->', req.object.toJSON());
+});
+
+Parse.Cloud.afterSave('Thing', (req /* , res */) => {
+  console.log('AFTER:',
+    req.original !== undefined ? req.original.toJSON() : undefined, '->', req.object.toJSON());
+});

--- a/test/original_in_aftersave/test_context.js
+++ b/test/original_in_aftersave/test_context.js
@@ -1,0 +1,14 @@
+const Parse = require('parse/node');
+
+Parse.initialize('test-app', null, 'M@stErK3y');
+Parse.serverURL = 'http://localhost:1337/parse';
+
+const Thing = Parse.Object.extend('Thing');
+const thing = new Thing();
+
+thing.save({ foo: 'bar' })
+     .then((t1) => {
+       console.log('Created %o', t1.toJSON());
+       return t1.save({ foo: 'baaaah' });
+     })
+     .then((t2) => console.log('Updated %o', t2.toJSON()));

--- a/test/test.js
+++ b/test/test.js
@@ -185,15 +185,19 @@ function behavesLikeParseObjectOnAfterSave(typeName, ParseObjectOrUserSubclass) 
   context('when object has afterSave hook registered', () => {
     let didAfterSave;
     let objectInAfterSave;
+    let originalObjectInAfterSave;
     function afterSavePromise(request) {
+      const { original, object } = request;
       didAfterSave = true;
-      objectInAfterSave = request.object;
+      originalObjectInAfterSave = original;
+      objectInAfterSave = object;
       return Promise.resolve();
     }
 
     beforeEach(() => {
       didAfterSave = false;
       objectInAfterSave = {};
+      originalObjectInAfterSave = {};
     });
 
     context('when saving a new object', () => {
@@ -280,6 +284,22 @@ function behavesLikeParseObjectOnAfterSave(typeName, ParseObjectOrUserSubclass) 
           assert.equal(
             objectInAfterSave.id,
             savedObject.id
+          );
+
+          assert.equal(
+            objectInAfterSave.get('name'),
+            'updated'
+          );
+        });
+      });
+
+      it('provide the original and saved object to the afterSave hook', () => {
+        ParseMockDB.registerHook(typeName, 'afterSave', afterSavePromise);
+        object.set('name', 'updated');
+        return object.save().then(() => {
+          assert.equal(
+            originalObjectInAfterSave.get('name'),
+            'original'
           );
 
           assert.equal(


### PR DESCRIPTION
This is my proposed fix for #91.

Happy to remove some of the extra test scripts and documentation; wanted them there to start with so I couldn't lose them and so others could see the full source.

All tests were passing when I pushed.

EDIT: motivation for this is that I have an `afterSave` hook that relies on identifying when a particular value has been incremented. Without this fix it's impossible for me to unit test that behaviour, so thought I'd give it a go.